### PR TITLE
MicroProfile Reactive Streams specification import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# microprofile-reactive
+# MicroProfile Reactive Specifications
 
 [![Join the chat at https://gitter.im/eclipse/microprofile-reactive](https://badges.gitter.im/eclipse/microprofile-reactive.svg)](https://gitter.im/eclipse/microprofile-reactive?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-Microprofile project
+
+This repo is the parent repository for all Reactive specifications in MicroProfile. It contains specifications for the following components:
+
+* [MicroProfile Reactive Streams](streams)

--- a/streams/.editorconfig
+++ b/streams/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.adoc]
+trim_trailing_whitespace = false

--- a/streams/.gitattributes
+++ b/streams/.gitattributes
@@ -1,0 +1,69 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.adoc          text
+*.conf          text
+*.config        text
+*.css           text
+*.df            text
+*.extension     text
+*.groovy        text
+*.htm           text
+*.html          text
+*.java          text
+*.js            text
+*.json          text
+*.jsp           text
+*.jspf          text
+*.md            text
+*.properties    text
+*.sbt           text
+*.scala         text
+*.sh            text
+*.sql           text
+*.svg           text
+*.template      text
+*.tld           text
+*.txt           text
+*.vm            text
+*.wadl          text
+*.wsdl          text
+*.xhtml         text
+*.xml           text
+*.xsd           text
+*.yml           text
+
+cipher          text
+jaas            text
+LICENSE         text
+NOTICE          text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.class         binary
+*.dll           binary
+*.ear           binary
+*.gif           binary
+*.ico           binary
+*.jar           binary
+*.jpg           binary
+*.jpeg          binary
+*.png           binary
+*.ser           binary
+*.so            binary
+*.war           binary
+*.zip           binary
+*.exe           binary
+*.gz            binary
+
+#Windows
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+#Unix/Linux
+*.sh text eol=lf

--- a/streams/.gitignore
+++ b/streams/.gitignore
@@ -1,0 +1,17 @@
+*.class
+.settings/
+.checkstyle
+target/
+tck/bin/
+.project
+build/
+.classpath
+.factorypath
+test-output
+/*.log
+.idea
+*.iml
+*.iwl
+*.ipr
+# Ignore a release.conf for perform_release/* script usage
+release.conf

--- a/streams/LICENSE
+++ b/streams/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/streams/NOTICE
+++ b/streams/NOTICE
@@ -1,0 +1,16 @@
+=========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for Microprofile Reactive Streams        ==
+=========================================================================
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+SPDXVersion: SPDX-2.1
+PackageName: Eclipse Microprofile
+PackageHomePage: http://www.eclipse.org/microprofile
+PackageLicenseDeclared: Apache-2.0
+
+PackageCopyrightText: <text>
+James Roper james@jazzy.id.au
+</text>

--- a/streams/README.adoc
+++ b/streams/README.adoc
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+image:https://badges.gitter.im/eclipse/microprofile-reactive.svg[link="https://gitter.im/eclipse/microprofile-reactive"]
+
+= Reactive Streams Support for MicroProfile
+
+== Rationale
+
+https://www.reactive-streams.org[Reactive Streams] is an integration SPI - it allows two different libraries that provide asynchronous streaming to be able to stream data to and from each other.
+
+Reactive Streams is not however designed to be used directly by application developers.
+The semantics defined by Reactive Streams are very strict, and are non trivial, particularly in the areas of thread safety, to implement correctly.
+Typically, application developers are expected to use third party libraries that provide the tools necessary to manipulate and control streams.
+Examples include https://doc.akka.io/docs/akka/2.5/stream/index.html[Akka Streams], https://github.com/ReactiveX/RxJava[RxJava] and https://projectreactor.io/[Reactor].
+
+Depending on third party libraries for this essential application developer facing functionality however is not something that MicroProfile can do.
+MicroProfile specifications are not allowed to depend on anything other than the JDK and other MicroProfile specifications.
+
+Hence, for MicroProfile to provide application developer APIs that use Reactive Streams, MicroProfile must provide its own Reactive Streams manipulation and control library.
+In future, it is hoped that this library will be adopted by the JDK itself, after a period of suitable incubation in the MicroProfile project.
+Some JDK maintainers have indicated that this would be a suitable path to get this type of functionality into the JDK.
+
+== Influences and History
+
+The naming and scope of this API is inspired by the JDK8 java.util.stream API.
+The JDK8 stream API however does not capture all typical functionality that an application developer using Reactive Streams would need.
+For additional API naming and scope, Akka Streams, RxJava and Reactor have been used as an inspiration.
+
+== Implementations
+
+MicroProfile Reactive Streams does not contain an implementation itself but only provides the specified API, a TCK and documentation.
+
+The following Implementations are available 
+
+* https://github.com/lightbind/microprofile-reactive-streams/tree/master/akka[Akka Streams]
+* https://github.com/lightbind/microprofile-reactive-streams/tree/master/zerodep[Zero Dependency] - intended as a possible reference implementation for when this is proposed to the JDK, but not the reference implementation for MicroProfile as MicroProfile does not have reference implementations.
+* https://github.com/lightbind/microprofile-reactive-streams/tree/master/rxjava[RxJava]
+
+== Design
+
+MicroProfile Reactive Streams offers a series of builders for creating instances of Reactive Streams `Publisher`, `Subscriber` and `Processor`.
+`Subscriber's` are associated with a `CompletionStage` of a result of consuming the stream, this may be the result of a reduction on the elements, or in some cases just indicates the termination of the stream either as a success or with an error.
+
+The API builds a graph from a series of graph stages, which are provided as an SPI.
+A Reactive Streams engine, which is implemented by implementations of the specification, and can also manually be provided by end users, is responsible for building the graph into a running stream.
+
+Reactive Streams is available in JDK9 in the `java.util.concurrent.Flow` API, however, MicroProfile is not ready to require a baseline JDK version above 8.
+For this reason, the same interfaces provided by https://www.reactive-streams.org in the `org.reactivestreams` package are used instead.
+This does place a dependency from MicroProfile to a third party library, however, that third party library is nothing more than the four Reactive Streams interfaces (`Publisher`, `Subscriber`, `Subscription` and `Processor`), and these have been copied as is into JDK9.
+As an interim solution while JDK9 adoption catches up, this has been deemed an acceptable exception to the rule.
+The approach documented in https://docs.google.com/document/d/1PEVm6viY4fR7fQyC6i-O-PSO2ciBMCdO9b2R3bsLAnk/edit[MicroProfile Approach to Reactive] for ensuring a smooth transition to the JDK9 APIs has been adopted.
+
+== Building
+
+The whole MicroProfile Reactive Streams project can be built via Apache Maven.
+
+`$> mvn clean install`
+

--- a/streams/api/bnd.bnd
+++ b/streams/api/bnd.bnd
@@ -1,0 +1,10 @@
+-exportcontents: \
+    org.eclipse.microprofile.*
+
+Import-Package: \
+    org.reactivestreams;version="[1.0.0,2)", \
+    *
+
+Bundle-SymbolicName: org.eclipse.microprofile.reactive.streams
+Bundle-Name: MicroProfile Reactive Streams Bundle
+Bundle-License: Apache License, Version 2.0

--- a/streams/api/pom.xml
+++ b/streams/api/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
+        <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+        <artifactId>microprofile-reactive-streams-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <bnd.baseline.include.distribution.management>false</bnd.baseline.include.distribution.management>
+    </properties>
+    <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+    <artifactId>microprofile-reactive-streams-api</artifactId>
+    <name>MicroProfile Reactive Streams API</name>
+    <description>MicroProfile Reactive Streams Support :: API</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <Bundle-SymbolicName>org.eclipse.microprofile.reactive.streams</Bundle-SymbolicName>
+                    <Bundle-Name>MicroProfile Reactive Streams Bundle</Bundle-Name>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-baseline-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <base>
+                        <version>1.0.0</version>
+                    </base>
+                </configuration>
+                <executions>
+                    <!--
+                    <execution>
+                        <id>baseline</id>
+                        <goals>
+                            <goal>baseline</goal>
+                        </goals>
+                    </execution>
+                    -->
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>eclipse-jarsigner</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                        <artifactId>eclipse-jarsigner-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionBuilder.java
@@ -34,14 +34,28 @@ import java.util.concurrent.CompletionStage;
  * @param <T> The result of the stream.
  * @see ReactiveStreams
  */
-public final class CompletionBuilder<T> extends ReactiveStreamsBuilder<CompletionStage<T>> {
+public final class CompletionBuilder<T> extends ReactiveStreamsBuilder {
 
-  CompletionBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+  CompletionBuilder(Stage stage, ReactiveStreamsBuilder previous) {
     super(stage, previous);
   }
 
-  @Override
-  public CompletionStage<T> build(ReactiveStreamsEngine engine) {
+  /**
+   * Run this stream, using the first {@link ReactiveStreamsEngine} found by the {@link java.util.ServiceLoader}.
+   *
+   * @return A completion stage that will be redeemed with the result of the stream, or an error if the stream fails.
+   */
+  public CompletionStage<T> run() {
+    return run(defaultEngine());
+  }
+
+  /**
+   * Run this stream, using the supplied {@link ReactiveStreamsEngine}.
+   *
+   * @param engine The engine to run the stream with.
+   * @return A completion stage that will be redeemed with the result of the stream, or an error if the stream fails.
+   */
+  public CompletionStage<T> run(ReactiveStreamsEngine engine) {
     return engine.buildCompletion(toGraph(false, false));
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionBuilder.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A builder for a closed reactive streams graph.
+ * <p>
+ * When built, this builder returns a {@link CompletionStage} that will be redeemed with the result produced by the
+ * subscriber of the stream when the stream completes normally, or will be redeemed with an error if the stream
+ * encounters an error.
+ *
+ * @param <T> The result of the stream.
+ * @see ReactiveStreams
+ */
+public final class CompletionBuilder<T> extends ReactiveStreamsBuilder<CompletionStage<T>> {
+
+  CompletionBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+    super(stage, previous);
+  }
+
+  @Override
+  public CompletionStage<T> build(ReactiveStreamsEngine engine) {
+    return engine.buildCompletion(toGraph(false, false));
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/InternalStages.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/InternalStages.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+
+/**
+ * Internal stages, used to capture the graph while being built, but never passed to a
+ * {@link org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine}.
+ */
+class InternalStages {
+
+  interface InternalStage extends Stage {
+  }
+
+  /**
+   * An identity stage - this stage simply passes is input to its output unchanged. It's used to represent processor
+   * builders that have had no stages defined.
+   * <p>
+   * It gets ignored by the {@link ReactiveStreamsBuilder} when encountered.
+   */
+  static final class Identity implements InternalStage {
+    private Identity() {
+    }
+
+    static final Identity INSTANCE = new Identity();
+  }
+
+  /**
+   * A nested stage. This is used to avoid having to rebuild the entire graph (which is represented as an immutable
+   * cons) whenever two graphs are joined, or a stage is prepended into the graph.
+   * <p>
+   * It gets flattened out by the {@link ReactiveStreamsBuilder} when building the graph.
+   */
+  static final class Nested implements InternalStage {
+    private final ReactiveStreamsBuilder stage;
+
+    Nested(ReactiveStreamsBuilder stage) {
+      this.stage = stage;
+    }
+
+    ReactiveStreamsBuilder getBuilder() {
+      return stage;
+    }
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Predicates.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Predicates.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import java.util.function.Predicate;
+
+/**
+ * Stateful predicates.
+ */
+class Predicates {
+
+  /**
+   * Predicate used to implement skip with a filter function.
+   */
+  static class SkipPredicate<T> implements Predicate<T> {
+    private final long toSkip;
+    private long count = 0;
+
+    SkipPredicate(long toSkip) {
+      this.toSkip = toSkip;
+    }
+
+    @Override
+    public boolean test(T t) {
+      if (count < toSkip) {
+        count++;
+        return false;
+      }
+      else {
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Predicate used to implement drop while with a filter function.
+   */
+  static class DropWhilePredicate<T> implements Predicate<T> {
+    private final Predicate<? super T> predicate;
+    private boolean dropping = true;
+
+    DropWhilePredicate(Predicate<? super T> predicate) {
+      this.predicate = predicate;
+    }
+
+    @Override
+    public boolean test(T t) {
+      if (dropping) {
+        if (predicate.test(t)) {
+          return false;
+        }
+        else {
+          dropping = true;
+          return true;
+        }
+      }
+      else {
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Predicate used to implement limit().
+   * <p>
+   * This returns false when the limit is reached, not exceeded, and is intended to be used with an inclusive takeWhile,
+   * this ensures that the stream completes as soon as the limit is reached, rather than having to wait for the next
+   * element before the stream is completed.
+   * <p>
+   * As a consequence, this can't be used with a limit of 0.
+   */
+  static class LimitPredicate<T> implements Predicate<T> {
+    private final long limitTo;
+    private long count = 0;
+
+    LimitPredicate(long limitTo) {
+      assert limitTo > 0;
+      this.limitTo = limitTo;
+    }
+
+    @Override
+    public boolean test(T t) {
+      return ++count < limitTo;
+    }
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Predicates.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Predicates.java
@@ -24,7 +24,10 @@ import java.util.function.Predicate;
 /**
  * Stateful predicates.
  */
-class Predicates {
+final class Predicates {
+
+  private Predicates() {
+  }
 
   /**
    * Predicate used to implement skip with a filter function.
@@ -67,7 +70,6 @@ class Predicates {
           return false;
         }
         else {
-          dropping = true;
           return true;
         }
       }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
@@ -1,0 +1,355 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * A builder for a {@link Processor}.
+ *
+ * @param <T> The type of the elements that the processor consumes.
+ * @param <R> The type of the elements that the processor emits.
+ * @see ReactiveStreams
+ */
+public final class ProcessorBuilder<T, R> extends ReactiveStreamsBuilder<Processor<T, R>> {
+
+  ProcessorBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+    super(stage, previous);
+  }
+
+  /**
+   * Map the elements emitted by this processor using the <code>mapper</code> function.
+   *
+   * @param mapper The function to use to map the elements.
+   * @param <S>    The type of elements that the <code>mapper</code> function emits.
+   * @return A new processor builder that consumes elements of type <code>T</code> and emits the mapped elements.
+   */
+  public <S> ProcessorBuilder<T, S> map(Function<? super R, ? extends S> mapper) {
+    return new ProcessorBuilder<>(new Stage.Map(mapper), this);
+  }
+
+  /**
+   * Filter elements emitted by this processor using the given {@link Predicate}.
+   * <p>
+   * Any elements that return <code>true</code> when passed to the {@link Predicate} will be emitted, all other
+   * elements will be dropped.
+   *
+   * @param predicate The predicate to apply to each element.
+   * @return A new processor builder.
+   */
+  public ProcessorBuilder<T, R> filter(Predicate<? super R> predicate) {
+    return new ProcessorBuilder<>(new Stage.Filter(() -> predicate), this);
+  }
+
+  /**
+   * Map the elements to publishers, and flatten so that the elements emitted by publishers produced by the
+   * {@code mapper} function are emitted from this stream.
+   * <p>
+   * This method operates on one publisher at a time. The result is a concatenation of elements emitted from all the
+   * publishers produced by the mapper function.
+   *
+   * @param mapper The mapper function.
+   * @param <S>    The type of the elements emitted from the new processor.
+   * @return A new processor builder.
+   */
+  public <S> ProcessorBuilder<T, S> flatMap(Function<? super R, PublisherBuilder<? extends S>> mapper) {
+    return new ProcessorBuilder<>(new Stage.FlatMap(mapper.andThen(PublisherBuilder::toGraph)), this);
+  }
+
+  /**
+   * Map the elements to {@link CompletionStage}, and flatten so that the elements the values redeemed by each
+   * {@link CompletionStage} are emitted from this processor.
+   * <p>
+   * This method only works with one element at a time. When an element is received, the {@code mapper} function is
+   * executed, and the next element is not consumed or passed to the {@code mapper} function until the previous
+   * {@link CompletionStage} is redeemed. Hence this method also guarantees that ordering of the stream is maintained.
+   *
+   * @param mapper The mapper function.
+   * @param <S>    The type of the elements emitted from the new processor.
+   * @return A new processor builder.
+   */
+  public <S> ProcessorBuilder<T, S> flatMapCompletionStage(Function<? super R, ? extends CompletionStage<? extends S>> mapper) {
+    return new ProcessorBuilder<>(new Stage.FlatMapCompletionStage((Function) mapper), this);
+  }
+
+  /**
+   * Map the elements to {@link Iterable}'s, and flatten so that the elements contained in each iterable are
+   * emitted by this stream.
+   * <p>
+   * This method operates on one iterable at a time. The result is a concatenation of elements contain in all the
+   * iterables returned by the {@code mapper} function.
+   *
+   * @param mapper The mapper function.
+   * @param <S>    The type of the elements emitted from the new processor.
+   * @return A new processor builder.
+   */
+  public <S> ProcessorBuilder<T, S> flatMapIterable(Function<? super R, ? extends Iterable<? extends S>> mapper) {
+    return new ProcessorBuilder<>(new Stage.FlatMapIterable((Function) mapper), this);
+  }
+
+  /**
+   * Truncate this stream, ensuring the stream is no longer than {@code maxSize} elements in length.
+   * <p>
+   * If {@code maxSize} is reached, the stream will be completed, and upstream will be cancelled. Completion of the
+   * stream will occur immediately when the element that satisfies the {@code maxSize} is received.
+   *
+   * @param maxSize The maximum size of the returned stream.
+   * @return A new processor builder.
+   */
+  public ProcessorBuilder<T, R> limit(long maxSize) {
+    if (maxSize < 0) {
+      throw new IllegalArgumentException("Cannot limit a stream to less than zero elements.");
+    }
+    else if (maxSize == 0) {
+      // todo this is perhaps not the desired behaviour - it means an element must be received before the stream will
+      // be completed. but then again, limiting a stream to have zero size is a strange thing to do, as running the
+      // stream in theory will then achieve nothing, so this edge case behavior probably isn't important to worry too
+      // much about.
+      return takeWhile(e -> false);
+    }
+    else {
+      return new ProcessorBuilder<>(new Stage.TakeWhile(() -> new Predicates.LimitPredicate<>(maxSize), true), this);
+    }
+  }
+
+  /**
+   * Discard the first {@code n} of this stream. If this stream contains fewer than {@code n} elements, this stream will
+   * effectively be an empty stream.
+   *
+   * @param n The number of elements to discard.
+   * @return A new processor builder.
+   */
+  public ProcessorBuilder<T, R> skip(long n) {
+    return new ProcessorBuilder<>(new Stage.Filter(() -> new Predicates.SkipPredicate<>(n)), this);
+  }
+
+  /**
+   * Take the longest prefix of elements from this stream that satisfy the given {@code predicate}.
+   * <p>
+   * When the {@code predicate} returns false, the stream will be completed, and upstream will be cancelled.
+   *
+   * @param predicate The predicate.
+   * @return A new publisher builder.
+   */
+  public ProcessorBuilder<T, R> takeWhile(Predicate<? super R> predicate) {
+    return new ProcessorBuilder<>(new Stage.TakeWhile(() -> predicate, false), this);
+  }
+
+  /**
+   * Drop the longest prefix of elements from this stream that satisfy the given {@code predicate}.
+   * <p>
+   * As long as the {@code predicate} returns true, no elements will be emitted from this stream. Once the first element
+   * is encountered for which the {@code predicate} returns false, all subsequent elements will be emitted, and the
+   * {@code predicate} will no longer be invoked.
+   *
+   * @param predicate The predicate.
+   * @return A new processor builder.
+   */
+  public ProcessorBuilder<T, R> dropWhile(Predicate<? super R> predicate) {
+    return new ProcessorBuilder<>(new Stage.Filter(() -> new Predicates.DropWhilePredicate<>(predicate)), this);
+  }
+
+  /**
+   * Performs an action for each element on this stream.
+   * <p>
+   * The returned {@link CompletionStage} from the {@link SubscriberWithResult} will be redeemed when the stream
+   * completes, either successfully if the stream completes normally, or with an error if the stream completes with an
+   * error or if the action throws an exception.
+   *
+   * @param action The action.
+   * @return A new subscriber builder.
+   */
+  public SubscriberBuilder<T, Void> forEach(Consumer<? super R> action) {
+    return collect(Collector.<R, Void, Void>of(
+        () -> null,
+        (n, r) -> action.accept(r),
+        (v1, v2) -> null,
+        v -> null
+    ));
+  }
+
+  /**
+   * Ignores each element of this stream.
+   * <p>
+   * The returned {@link CompletionStage} from the {@link SubscriberWithResult} will be redeemed when the stream
+   * completes, either successfully if the stream completes normally, or with an error if the stream completes with an
+   * error or if the action throws an exception.
+   *
+   * @return A new subscriber builder.
+   */
+  public SubscriberBuilder<T, Void> ignore() {
+    return forEach(r -> {
+    });
+  }
+
+  /**
+   * Cancels the stream as soon as it starts.
+   * <p>
+   * The returned {@link CompletionStage} from the {@link SubscriberWithResult} will be immediately redeemed as soon
+   * as the stream starts.
+   *
+   * @return A new subscriber builder.
+   */
+  public SubscriberBuilder<T, Void> cancel() {
+    return new SubscriberBuilder<>(Stage.Cancel.INSTANCE, this);
+  }
+
+  /**
+   * Perform a reduction on the elements of this stream, using the provided identity value and the accumulation
+   * function.
+   * <p>
+   * The result of the reduction is returned in the {@link SubscriberWithResult}.
+   *
+   * @param identity    The identity value.
+   * @param accumulator The accumulator function.
+   * @return A new subscriber builder.
+   */
+  public SubscriberBuilder<T, R> reduce(R identity, BinaryOperator<R> accumulator) {
+    return new SubscriberBuilder<>(new Stage.Collect(Reductions.reduce(identity, accumulator)), this);
+  }
+
+  /**
+   * Perform a reduction on the elements of this stream, using provided the accumulation function.
+   * <p>
+   * The result of the reduction is returned in the {@link SubscriberWithResult}. If there are no elements in this stream,
+   * empty will be returned.
+   *
+   * @param accumulator The accumulator function.
+   * @return A new subscriber builder.
+   */
+  public SubscriberBuilder<T, Optional<R>> reduce(BinaryOperator<R> accumulator) {
+    return new SubscriberBuilder<>(new Stage.Collect(Reductions.reduce(accumulator)), this);
+  }
+
+  /**
+   * Perform a reduction on the elements of this stream, using the provided identity value, accumulation function and
+   * combiner function.
+   * <p>
+   * The result of the reduction is returned in the {@link SubscriberWithResult}.
+   *
+   * @param identity    The identity value.
+   * @param accumulator The accumulator function.
+   * @param combiner    The combiner function.
+   * @return A new subscriber builder.
+   */
+  public <S> SubscriberBuilder<T, S> reduce(S identity,
+      BiFunction<S, ? super R, S> accumulator,
+      BinaryOperator<S> combiner) {
+
+    return new SubscriberBuilder<>(new Stage.Collect(Reductions.reduce(identity, accumulator, combiner)), this);
+  }
+
+  /**
+   * Collect the elements emitted by this processor builder using the given {@link Collector}.
+   * <p>
+   * Since Reactive Streams are intrinsically sequential, only the accumulator of the collector will be used, the
+   * combiner will not be used.
+   *
+   * @param collector The collector to collect the elements.
+   * @param <S>       The result of the collector.
+   * @param <A>       The accumulator type.
+   * @return A {@link SubscriberBuilder} that represents this processor builders inlet.
+   */
+  public <S, A> SubscriberBuilder<T, S> collect(Collector<? super R, A, S> collector) {
+    return new SubscriberBuilder<>(new Stage.Collect(collector), this);
+  }
+
+  /**
+   * Collect the elements emitted by this processor builder into a {@link List}
+   *
+   * @return A {@link SubscriberBuilder} that represents this processor builders inlet.
+   */
+  public SubscriberBuilder<T, List<R>> toList() {
+    return collect(Collectors.toList());
+  }
+
+  /**
+   * Find the first element emitted by the {@link Processor}, and return it in a
+   * {@link CompletionStage}.
+   * <p>
+   * If the stream is completed before a single element is emitted, then {@link Optional#empty()} will be emitted.
+   *
+   * @return A {@link SubscriberBuilder} that represents this processor builders inlet.
+   */
+  public SubscriberBuilder<T, Optional<R>> findFirst() {
+    return new SubscriberBuilder<>(Stage.FindFirst.INSTANCE, this);
+  }
+
+  /**
+   * Connect the outlet of the {@link Processor} built by this builder to the given {@link Subscriber}.
+   *
+   * @param subscriber The subscriber to connect.
+   * @return A {@link SubscriberBuilder} that represents this processor builders inlet.
+   */
+  public SubscriberBuilder<T, Void> to(Subscriber<R> subscriber) {
+    return new SubscriberBuilder<>(new Stage.SubscriberStage(subscriber), this);
+  }
+
+  /**
+   * Connect the outlet of this processor builder to the given {@link SubscriberBuilder} graph.
+   *
+   * @param subscriber The subscriber builder to connect.
+   * @return A {@link SubscriberBuilder} that represents this processor builders inlet.
+   */
+  public <S> SubscriberBuilder<T, S> to(SubscriberBuilder<R, S> subscriber) {
+    return new SubscriberBuilder<>(new InternalStages.Nested(subscriber), this);
+  }
+
+  /**
+   * Connect the outlet of the {@link Processor} built by this builder to the given {@link Processor}.
+   *
+   * @param processor The processor to connect.
+   * @return A {@link ProcessorBuilder} that represents this processor builders inlet, and the passed in processors
+   * outlet.
+   */
+  public <S> ProcessorBuilder<T, S> via(ProcessorBuilder<R, S> processor) {
+    return new ProcessorBuilder<>(new InternalStages.Nested(processor), this);
+  }
+
+  /**
+   * Connect the outlet of this processor builder to the given {@link ProcessorBuilder} graph.
+   *
+   * @param processor The processor builder to connect.
+   * @return A {@link ProcessorBuilder} that represents this processor builders inlet, and the passed in
+   * processor builders outlet.
+   */
+  public <S> ProcessorBuilder<T, S> via(Processor<R, S> processor) {
+    return new ProcessorBuilder<>(new Stage.ProcessorStage(processor), this);
+  }
+
+  @Override
+  public Processor<T, R> build(ReactiveStreamsEngine engine) {
+    return engine.buildProcessor(toGraph(true, true));
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
@@ -42,9 +42,9 @@ import java.util.stream.Collectors;
  * @param <R> The type of the elements that the processor emits.
  * @see ReactiveStreams
  */
-public final class ProcessorBuilder<T, R> extends ReactiveStreamsBuilder<Processor<T, R>> {
+public final class ProcessorBuilder<T, R> extends ReactiveStreamsBuilder {
 
-  ProcessorBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+  ProcessorBuilder(Stage stage, ReactiveStreamsBuilder previous) {
     super(stage, previous);
   }
 
@@ -348,8 +348,22 @@ public final class ProcessorBuilder<T, R> extends ReactiveStreamsBuilder<Process
     return new ProcessorBuilder<>(new Stage.ProcessorStage(processor), this);
   }
 
-  @Override
-  public Processor<T, R> build(ReactiveStreamsEngine engine) {
+  /**
+   * Build this stream, using the first {@link ReactiveStreamsEngine} found by the {@link java.util.ServiceLoader}.
+   *
+   * @return A {@link Processor} that will run this stream.
+   */
+  public Processor<T, R> buildRs() {
+    return buildRs(defaultEngine());
+  }
+
+  /**
+   * Build this stream, using the supplied {@link ReactiveStreamsEngine}.
+   *
+   * @param engine The engine to run the stream with.
+   * @return A {@link Processor} that will run this stream.
+   */
+  public Processor<T, R> buildRs(ReactiveStreamsEngine engine) {
     return engine.buildProcessor(toGraph(true, true));
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
@@ -1,0 +1,353 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * A builder for a {@link Publisher}.
+ *
+ * @param <T> The type of the elements that the publisher emits.
+ * @see ReactiveStreams
+ */
+public final class PublisherBuilder<T> extends ReactiveStreamsBuilder<Publisher<T>> {
+
+  PublisherBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+    super(stage, previous);
+  }
+
+  /**
+   * Map the elements emitted by this publisher using the {@code mapper} function.
+   *
+   * @param mapper The function to use to map the elements.
+   * @param <R>    The type of elements that the {@code mapper} function emits.
+   * @return A new publisher builder that emits the mapped elements.
+   */
+  public <R> PublisherBuilder<R> map(Function<? super T, ? extends R> mapper) {
+    return new PublisherBuilder<>(new Stage.Map(mapper), this);
+  }
+
+  /**
+   * Filter elements emitted by this publisher using the given {@link Predicate}.
+   * <p>
+   * Any elements that return {@code true} when passed to the {@link Predicate} will be emitted, all other
+   * elements will be dropped.
+   *
+   * @param predicate The predicate to apply to each element.
+   * @return A new publisher builder.
+   */
+  public PublisherBuilder<T> filter(Predicate<? super T> predicate) {
+    return new PublisherBuilder<>(new Stage.Filter(() -> predicate), this);
+  }
+
+  /**
+   * Map the elements to publishers, and flatten so that the elements emitted by publishers produced by the
+   * {@code mapper} function are emitted from this stream.
+   * <p>
+   * This method operates on one publisher at a time. The result is a concatenation of elements emitted from all the
+   * publishers produced by the mapper function.
+   *
+   * @param mapper The mapper function.
+   * @param <S>    The type of the elements emitted from the new publisher.
+   * @return A new publisher builder.
+   */
+  public <S> PublisherBuilder<S> flatMap(Function<? super T, PublisherBuilder<? extends S>> mapper) {
+    return new PublisherBuilder<>(new Stage.FlatMap(
+        mapper.andThen(PublisherBuilder::toGraph)), this);
+  }
+
+  /**
+   * Map the elements to {@link CompletionStage}, and flatten so that the elements the values redeemed by each
+   * {@link CompletionStage} are emitted from this publisher.
+   * <p>
+   * This method only works with one element at a time. When an element is received, the {@code mapper} function is
+   * executed, and the next element is not consumed or passed to the {@code mapper} function until the previous
+   * {@link CompletionStage} is redeemed. Hence this method also guarantees that ordering of the stream is maintained.
+   *
+   * @param mapper The mapper function.
+   * @param <S>    The type of the elements emitted from the new publisher.
+   * @return A new publisher builder.
+   */
+  public <S> PublisherBuilder<S> flatMapCompletionStage(Function<? super T, ? extends CompletionStage<? extends S>> mapper) {
+    return new PublisherBuilder<>(new Stage.FlatMapCompletionStage((Function) mapper), this);
+  }
+
+  /**
+   * Map the elements to {@link Iterable}'s, and flatten so that the elements contained in each iterable are
+   * emitted by this stream.
+   * <p>
+   * This method operates on one iterable at a time. The result is a concatenation of elements contain in all the
+   * iterables returned by the {@code mapper} function.
+   *
+   * @param mapper The mapper function.
+   * @param <S>    The type of the elements emitted from the new publisher.
+   * @return A new publisher builder.
+   */
+  public <S> PublisherBuilder<S> flatMapIterable(Function<? super T, ? extends Iterable<? extends S>> mapper) {
+    return new PublisherBuilder<>(new Stage.FlatMapIterable((Function) mapper), this);
+  }
+
+  /**
+   * Truncate this stream, ensuring the stream is no longer than {@code maxSize} elements in length.
+   * <p>
+   * If {@code maxSize} is reached, the stream will be completed, and upstream will be cancelled. Completion of the
+   * stream will occur immediately when the element that satisfies the {@code maxSize} is received.
+   *
+   * @param maxSize The maximum size of the returned stream.
+   * @return A new publisher builder.
+   */
+  public PublisherBuilder<T> limit(long maxSize) {
+    if (maxSize < 0) {
+      throw new IllegalArgumentException("Cannot limit a stream to less than zero elements.");
+    }
+    else if (maxSize == 0) {
+      return takeWhile(e -> false);
+    }
+    else {
+      return new PublisherBuilder<>(new Stage.TakeWhile(() -> new Predicates.LimitPredicate<>(maxSize), true), this);
+    }
+  }
+
+  /**
+   * Discard the first {@code n} of this stream. If this stream contains fewer than {@code n} elements, this stream will
+   * effectively be an empty stream.
+   *
+   * @param n The number of elements to discard.
+   * @return A new publisher builder.
+   */
+  public PublisherBuilder<T> skip(long n) {
+    return new PublisherBuilder<>(new Stage.Filter(() -> new Predicates.SkipPredicate<>(n)), this);
+  }
+
+  /**
+   * Take the longest prefix of elements from this stream that satisfy the given {@code predicate}.
+   * <p>
+   * When the {@code predicate} returns false, the stream will be completed, and upstream will be cancelled.
+   *
+   * @param predicate The predicate.
+   * @return A new publisher builder.
+   */
+  public PublisherBuilder<T> takeWhile(Predicate<? super T> predicate) {
+    return new PublisherBuilder<>(new Stage.TakeWhile(() -> predicate, false), this);
+  }
+
+  /**
+   * Drop the longest prefix of elements from this stream that satisfy the given {@code predicate}.
+   * <p>
+   * As long as the {@code predicate} returns true, no elements will be emitted from this stream. Once the first element
+   * is encountered for which the {@code predicate} returns false, all subsequent elements will be emitted, and the
+   * {@code predicate} will no longer be invoked.
+   *
+   * @param predicate The predicate.
+   * @return A new publisher builder.
+   */
+  public PublisherBuilder<T> dropWhile(Predicate<? super T> predicate) {
+    return new PublisherBuilder<>(new Stage.Filter(() -> new Predicates.DropWhilePredicate<>(predicate)), this);
+  }
+
+  /**
+   * Performs an action for each element on this stream.
+   * <p>
+   * The returned {@link CompletionStage} will be redeemed when the stream completes, either successfully if the stream
+   * completes normally, or with an error if the stream completes with an error or if the action throws an exception.
+   *
+   * @param action The action.
+   * @return A new completion builder.
+   */
+  public CompletionBuilder<Void> forEach(Consumer<? super T> action) {
+    return collect(Collector.<T, Void, Void>of(
+        () -> null,
+        (n, t) -> action.accept(t),
+        (v1, v2) -> null,
+        v -> null
+    ));
+  }
+
+  /**
+   * Ignores each element of this stream.
+   * <p>
+   * The returned {@link CompletionStage} will be redeemed when the stream completes, either successfully if the
+   * stream completes normally, or with an error if the stream completes with an error or if the action throws an
+   * exception.
+   *
+   * @return A new completion builder.
+   */
+  public CompletionBuilder<Void> ignore() {
+    return forEach(r -> {
+    });
+  }
+
+  /**
+   * Cancels the stream as soon as it starts.
+   * <p>
+   * The returned {@link CompletionStage} will be immediately redeemed as soon as the stream starts.
+   *
+   * @return A new completion builder.
+   */
+  public CompletionBuilder<Void> cancel() {
+    return new CompletionBuilder<>(Stage.Cancel.INSTANCE, this);
+  }
+
+  /**
+   * Perform a reduction on the elements of this stream, using the provided identity value and the accumulation
+   * function.
+   * <p>
+   * The result of the reduction is returned in the {@link CompletionStage}.
+   *
+   * @param identity    The identity value.
+   * @param accumulator The accumulator function.
+   * @return A new completion builder.
+   */
+  public CompletionBuilder<T> reduce(T identity, BinaryOperator<T> accumulator) {
+    return new CompletionBuilder<>(new Stage.Collect(Reductions.reduce(identity, accumulator)), this);
+  }
+
+  /**
+   * Perform a reduction on the elements of this stream, using provided the accumulation function.
+   * <p>
+   * The result of the reduction is returned in the {@link CompletionStage}. If there are no elements in this stream,
+   * empty will be returned.
+   *
+   * @param accumulator The accumulator function.
+   * @return A new completion builder.
+   */
+  public CompletionBuilder<Optional<T>> reduce(BinaryOperator<T> accumulator) {
+    return new CompletionBuilder<>(new Stage.Collect(Reductions.reduce(accumulator)), this);
+  }
+
+  /**
+   * Perform a reduction on the elements of this stream, using the provided identity value, accumulation function and
+   * combiner function.
+   * <p>
+   * The result of the reduction is returned in the {@link CompletionStage}.
+   *
+   * @param identity    The identity value.
+   * @param accumulator The accumulator function.
+   * @param combiner    The combiner function.
+   * @return A new completion builder.
+   */
+  public <S> CompletionBuilder<S> reduce(S identity,
+      BiFunction<S, ? super T, S> accumulator,
+      BinaryOperator<S> combiner) {
+
+    return new CompletionBuilder<>(new Stage.Collect(Reductions.reduce(identity, accumulator, combiner)), this);
+  }
+
+  /**
+   * Find the first element emitted by the {@link Publisher}, and return it in a
+   * {@link CompletionStage}.
+   * <p>
+   * If the stream is completed before a single element is emitted, then {@link Optional#empty()} will be emitted.
+   *
+   * @return A {@link CompletionBuilder} that emits the element when found.
+   */
+  public CompletionBuilder<Optional<T>> findFirst() {
+    return new CompletionBuilder<>(Stage.FindFirst.INSTANCE, this);
+  }
+
+  /**
+   * Collect the elements emitted by this publisher builder using the given {@link Collector}.
+   * <p>
+   * Since Reactive Streams are intrinsically sequential, only the accumulator of the collector will be used, the
+   * combiner will not be used.
+   *
+   * @param collector The collector to collect the elements.
+   * @param <R>       The result of the collector.
+   * @param <A>       The accumulator type.
+   * @return A {@link CompletionBuilder} that emits the collected result.
+   */
+  public <R, A> CompletionBuilder<R> collect(Collector<? super T, A, R> collector) {
+    return new CompletionBuilder<>(new Stage.Collect(collector), this);
+  }
+
+  /**
+   * Collect the elements emitted by this publisher builder into a {@link List}
+   *
+   * @return A {@link CompletionBuilder} that emits the list.
+   */
+  public CompletionBuilder<List<T>> toList() {
+    return collect(Collectors.toList());
+  }
+
+  /**
+   * Connect the outlet of the {@link Publisher} built by this builder to the given {@link Subscriber}.
+   *
+   * @param subscriber The subscriber to connect.
+   * @return A {@link CompletionBuilder} that completes when the stream completes.
+   */
+  public CompletionBuilder<Void> to(Subscriber<T> subscriber) {
+    return new CompletionBuilder<>(new Stage.SubscriberStage(subscriber), this);
+  }
+
+  /**
+   * Connect the outlet of this publisher builder to the given {@link SubscriberBuilder} graph.
+   *
+   * @param subscriber The subscriber builder to connect.
+   * @return A {@link CompletionBuilder} that completes when the stream completes.
+   */
+  public <R> CompletionBuilder<R> to(SubscriberBuilder<T, R> subscriber) {
+    return new CompletionBuilder<>(new InternalStages.Nested(subscriber), this);
+  }
+
+  /**
+   * Connect the outlet of the {@link Publisher} built by this builder to the given {@link Processor}.
+   *
+   * @param processor The processor to connect.
+   * @return A {@link PublisherBuilder} that represents the passed in processors outlet.
+   */
+  public <R> PublisherBuilder<R> via(ProcessorBuilder<T, R> processor) {
+    return new PublisherBuilder<>(new InternalStages.Nested(processor), this);
+  }
+
+  /**
+   * Connect the outlet of this publisher builder to the given {@link ProcessorBuilder} graph.
+   *
+   * @param processor The processor builder to connect.
+   * @return A {@link PublisherBuilder} that represents the passed in processor builders outlet.
+   */
+  public <R> PublisherBuilder<R> via(Processor<T, R> processor) {
+    return new PublisherBuilder<>(new Stage.ProcessorStage(processor), this);
+  }
+
+  Graph toGraph() {
+    return toGraph(false, true);
+  }
+
+  @Override
+  public Publisher<T> build(ReactiveStreamsEngine engine) {
+    return engine.buildPublisher(toGraph());
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
@@ -43,9 +43,9 @@ import java.util.stream.Collectors;
  * @param <T> The type of the elements that the publisher emits.
  * @see ReactiveStreams
  */
-public final class PublisherBuilder<T> extends ReactiveStreamsBuilder<Publisher<T>> {
+public final class PublisherBuilder<T> extends ReactiveStreamsBuilder {
 
-  PublisherBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+  PublisherBuilder(Stage stage, ReactiveStreamsBuilder previous) {
     super(stage, previous);
   }
 
@@ -346,8 +346,22 @@ public final class PublisherBuilder<T> extends ReactiveStreamsBuilder<Publisher<
     return toGraph(false, true);
   }
 
-  @Override
-  public Publisher<T> build(ReactiveStreamsEngine engine) {
+  /**
+   * Build this stream, using the first {@link ReactiveStreamsEngine} found by the {@link java.util.ServiceLoader}.
+   *
+   * @return A {@link Processor} that will run this stream.
+   */
+  public Publisher<T> buildRs() {
+    return buildRs(defaultEngine());
+  }
+
+  /**
+   * Build this stream, using the supplied {@link ReactiveStreamsEngine}.
+   *
+   * @param engine The engine to run the stream with.
+   * @return A {@link Publisher} that will run this stream.
+   */
+  public Publisher<T> buildRs(ReactiveStreamsEngine engine) {
     return engine.buildPublisher(toGraph());
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+/**
+ * Primary entry point into the Reactive Streams utility API.
+ * <p>
+ * This class provides factory methods for publisher and processor builders, which can then be subsequently manipulated
+ * using their respective APIs.
+ */
+public class ReactiveStreams {
+
+  private ReactiveStreams() {
+  }
+
+  /**
+   * Create a {@link PublisherBuilder} from the given {@link Publisher}.
+   *
+   * @param publisher The publisher to wrap.
+   * @param <T>       The type of the elements that the publisher produces.
+   * @return A publisher builder that wraps the given publisher.
+   */
+  public static <T> PublisherBuilder<T> fromPublisher(Publisher<? extends T> publisher) {
+    return new PublisherBuilder<>(new Stage.PublisherStage(publisher), null);
+  }
+
+  /**
+   * Create a {@link PublisherBuilder} that emits a single element.
+   *
+   * @param t   The element to emit.
+   * @param <T> The type of the element.
+   * @return A publisher builder that will emit the element.
+   */
+  public static <T> PublisherBuilder<T> of(T t) {
+    return new PublisherBuilder<>(new Stage.Of(Arrays.asList(t)), null);
+  }
+
+  /**
+   * Create a {@link PublisherBuilder} that emits the given elements.
+   *
+   * @param ts  The elements to emit.
+   * @param <T> The type of the elements.
+   * @return A publisher builder that will emit the elements.
+   */
+  public static <T> PublisherBuilder<T> of(T... ts) {
+    return fromIterable(Arrays.asList(ts));
+  }
+
+  /**
+   * Create an empty {@link PublisherBuilder}.
+   *
+   * @param <T> The type of the publisher builder.
+   * @return A publisher builder that will just emit a completion signal.
+   */
+  public static <T> PublisherBuilder<T> empty() {
+    return new PublisherBuilder<>(Stage.Of.EMPTY, null);
+  }
+
+  /**
+   * Create a {@link PublisherBuilder} that will emit a single element if <code>t</code> is not null, otherwise will be
+   * empty.
+   *
+   * @param t   The element to emit, <code>null</code> if to element should be emitted.
+   * @param <T> The type of the element.
+   * @return A publisher builder that optionally emits a single element.
+   */
+  public static <T> PublisherBuilder<T> ofNullable(T t) {
+    return t == null ? empty() : of(t);
+  }
+
+  /**
+   * Create a {@link PublisherBuilder} that will emits the elements produced by the passed in {@link Iterable}.
+   *
+   * @param ts  The elements to emit.
+   * @param <T> The type of the elements.
+   * @return A publisher builder that emits the elements of the iterable.
+   */
+  public static <T> PublisherBuilder<T> fromIterable(Iterable<? extends T> ts) {
+    return new PublisherBuilder<>(new Stage.Of(ts), null);
+  }
+
+  /**
+   * Create a failed {@link PublisherBuilder}.
+   * <p>
+   * This publisher will just emit an error.
+   *
+   * @param t   The error te emit.
+   * @param <T> The type of the publisher builder.
+   * @return A publisher builder that completes the stream with an error.
+   */
+  public static <T> PublisherBuilder<T> failed(Throwable t) {
+    return new PublisherBuilder<>(new Stage.Failed(t), null);
+  }
+
+  /**
+   * Create a {@link ProcessorBuilder}. This builder will start as an identity processor.
+   *
+   * @param <T> The type of elements that the processor consumes and emits.
+   * @return The identity processor builder.
+   */
+  public static <T> ProcessorBuilder<T, T> builder() {
+    return new ProcessorBuilder<>(InternalStages.Identity.INSTANCE, null);
+  }
+
+  /**
+   * Create a {@link ProcessorBuilder} from the given {@link Processor}.
+   *
+   * @param processor The processor to be wrapped.
+   * @param <T>       The type of the elements that the processor consumes.
+   * @param <R>       The type of the elements that the processor emits.
+   * @return A processor builder that wraps the processor.
+   */
+  public static <T, R> ProcessorBuilder<T, R> fromProcessor(Processor<? super T, ? extends R> processor) {
+    return new ProcessorBuilder<>(new Stage.ProcessorStage(processor), null);
+  }
+
+  /**
+   * Create a {@link SubscriberBuilder} from the given {@link Subscriber}.
+   *
+   * @param subscriber The subscriber to be wrapped.
+   * @param <T>        The type of elements that the subscriber consumes.
+   * @return A subscriber builder that wraps the subscriber.
+   */
+  public static <T> SubscriberBuilder<T, Void> fromSubscriber(Subscriber<? extends T> subscriber) {
+    return new SubscriberBuilder<>(new Stage.SubscriberStage(subscriber), null);
+  }
+
+  /**
+   * Creates an infinite stream produced by the iterative application of the function {@code f} to an initial element
+   * {@code seed} consisting of {@code seed}, {@code f(seed)}, {@code f(f(seed))}, etc.
+   *
+   * @param seed The initial element.
+   * @param f    A function applied to the previous element to produce the next element.
+   * @param <T>  The type of stream elements.
+   * @return A publisher builder.
+   */
+  public static <T> PublisherBuilder<T> iterate(T seed, UnaryOperator<T> f) {
+    return fromIterable(() -> Stream.iterate(seed, f).iterator());
+  }
+
+  /**
+   * Creates an infinite stream that emits elements supplied by the supplier {@code s}.
+   *
+   * @param s   The supplier.
+   * @param <T> The type of stream elements.
+   * @return A publisher builder.
+   */
+  public static <T> PublisherBuilder<T> generate(Supplier<? extends T> s) {
+    return fromIterable(() -> Stream.<T>generate(s).iterator());
+  }
+
+  /**
+   * Concatenates two publishers.
+   * <p>
+   * The resulting stream will be produced by subscribing to the first publisher, and emitting the elements it emits,
+   * until it emits a completion signal, at which point the second publisher will be subscribed to, and its elements
+   * will be emitted.
+   * <p>
+   * If the first publisher completes with an error signal, then the second publisher will be subscribed to but
+   * immediately cancelled, none of its elements will be emitted. This ensures that hot publishers are cleaned up.
+   * If downstream emits a cancellation signal before the first publisher finishes, it will be passed to both
+   * publishers.
+   *
+   * @param a   The first publisher.
+   * @param b   The second publisher.
+   * @param <T> The type of stream elements.
+   * @return A publisher builder.
+   */
+  public static <T> PublisherBuilder<T> concat(PublisherBuilder<? extends T> a,
+      PublisherBuilder<? extends T> b) {
+    return new PublisherBuilder<>(new Stage.Concat(a.toGraph(), b.toGraph()), null);
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
@@ -173,7 +173,7 @@ public class ReactiveStreams {
    * @return A publisher builder.
    */
   public static <T> PublisherBuilder<T> generate(Supplier<? extends T> s) {
-    return fromIterable(() -> Stream.<T>generate(s).iterator());
+    return fromIterable(() -> Stream.<T>generate((Supplier) s).iterator());
   }
 
   /**

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreamsBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreamsBuilder.java
@@ -78,18 +78,18 @@ public abstract class ReactiveStreamsBuilder {
   }
 
   private void flatten(Deque<Stage> stages) {
-    if (stage == InternalStages.Identity.INSTANCE) {
-      // Ignore, no need to add an identity stage
-    }
-    else if (stage instanceof InternalStages.Nested) {
-      ((InternalStages.Nested) stage).getBuilder().flatten(stages);
-    }
-    else {
-      stages.addFirst(stage);
-    }
-
-    if (previous != null) {
-      previous.flatten(stages);
+    ReactiveStreamsBuilder thisStage = this;
+    while (thisStage != null) {
+      if (thisStage.stage == InternalStages.Identity.INSTANCE) {
+        // Ignore, no need to add an identity stage
+      }
+      else if (thisStage.stage instanceof InternalStages.Nested) {
+        ((InternalStages.Nested) thisStage.stage).getBuilder().flatten(stages);
+      }
+      else {
+        stages.addFirst(thisStage.stage);
+      }
+      thisStage = thisStage.previous;
     }
   }
 

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreamsBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreamsBuilder.java
@@ -28,42 +28,28 @@ import java.util.*;
 /**
  * Superclass of all reactive streams builders.
  *
- * @param <S> The shape of the graph being built.
  * @see ReactiveStreams
  */
-public abstract class ReactiveStreamsBuilder<S> {
+public abstract class ReactiveStreamsBuilder {
 
   private final Stage stage;
-  private final ReactiveStreamsBuilder<?> previous;
+  private final ReactiveStreamsBuilder previous;
 
-  ReactiveStreamsBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+  ReactiveStreamsBuilder(Stage stage, ReactiveStreamsBuilder previous) {
     this.stage = stage;
     this.previous = previous;
   }
 
-  /**
-   * Build this stream, using the first {@link ReactiveStreamsEngine} found by the {@link ServiceLoader}.
-   *
-   * @return The graph of the given shape.
-   */
-  public S build() {
+  protected ReactiveStreamsEngine defaultEngine() {
     Iterator<ReactiveStreamsEngine> engines = ServiceLoader.load(ReactiveStreamsEngine.class).iterator();
 
     if (engines.hasNext()) {
-      return build(engines.next());
+      return engines.next();
     }
     else {
       throw new IllegalStateException("No implementation of ReactiveStreamsEngine service could be found.");
     }
   }
-
-  /**
-   * Build this stream, using the supplied {@link ReactiveStreamsEngine}.
-   *
-   * @param engine The engine to build the stream with.
-   * @return The graph of the given shape.
-   */
-  public abstract S build(ReactiveStreamsEngine engine);
 
   Graph toGraph(boolean expectInlet, boolean expectOutlet) {
     ArrayDeque<Stage> deque = new ArrayDeque<>();

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreamsBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreamsBuilder.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+
+import java.util.*;
+
+/**
+ * Superclass of all reactive streams builders.
+ *
+ * @param <S> The shape of the graph being built.
+ * @see ReactiveStreams
+ */
+public abstract class ReactiveStreamsBuilder<S> {
+
+  private final Stage stage;
+  private final ReactiveStreamsBuilder<?> previous;
+
+  ReactiveStreamsBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+    this.stage = stage;
+    this.previous = previous;
+  }
+
+  /**
+   * Build this stream, using the first {@link ReactiveStreamsEngine} found by the {@link ServiceLoader}.
+   *
+   * @return The graph of the given shape.
+   */
+  public S build() {
+    Iterator<ReactiveStreamsEngine> engines = ServiceLoader.load(ReactiveStreamsEngine.class).iterator();
+
+    if (engines.hasNext()) {
+      return build(engines.next());
+    }
+    else {
+      throw new IllegalStateException("No implementation of ReactiveStreamsEngine service could be found.");
+    }
+  }
+
+  /**
+   * Build this stream, using the supplied {@link ReactiveStreamsEngine}.
+   *
+   * @param engine The engine to build the stream with.
+   * @return The graph of the given shape.
+   */
+  public abstract S build(ReactiveStreamsEngine engine);
+
+  Graph toGraph(boolean expectInlet, boolean expectOutlet) {
+    ArrayDeque<Stage> deque = new ArrayDeque<>();
+    flatten(deque);
+    Graph graph = new Graph(Collections.unmodifiableCollection(deque));
+
+    if (expectInlet) {
+      if (!graph.hasInlet()) {
+        throw new IllegalStateException("Expected to build a graph with an inlet, but no inlet was found: " + graph);
+      }
+    }
+    else if (graph.hasInlet()) {
+      throw new IllegalStateException("Expected to build a graph with no inlet, but an inlet was found: " + graph);
+    }
+
+    if (expectOutlet) {
+      if (!graph.hasOutlet()) {
+        throw new IllegalStateException("Expected to build a graph with an outlet, but no outlet was found: " + graph);
+      }
+    }
+    else if (graph.hasOutlet()) {
+      throw new IllegalStateException("Expected to build a graph with no outlet, but an outlet was found: " + graph);
+    }
+
+    return graph;
+  }
+
+  private void flatten(Deque<Stage> stages) {
+    if (stage == InternalStages.Identity.INSTANCE) {
+      // Ignore, no need to add an identity stage
+    }
+    else if (stage instanceof InternalStages.Nested) {
+      ((InternalStages.Nested) stage).getBuilder().flatten(stages);
+    }
+    else {
+      stages.addFirst(stage);
+    }
+
+    if (previous != null) {
+      previous.flatten(stages);
+    }
+  }
+
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Reductions.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Reductions.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.stream.Collector;
+
+/**
+ * Reduction utilities that convert arguments supplied to reduce methods on the builders to Collectors.
+ */
+class Reductions {
+
+  private Reductions() {
+  }
+
+  static <T> Collector<T, ?, Optional<T>> reduce(BinaryOperator<T> reducer) {
+
+    return Collector.of(Reduction<T>::new,
+        (r, t) -> {
+          if (r.value == null) {
+            r.value = t;
+          }
+          else {
+            r.value = reducer.apply(r.value, t);
+          }
+        },
+        (r, s) -> {
+          if (r.value == null) {
+            return r.replace(s.value);
+          }
+          else if (s.value != null) {
+            return r.replace(reducer.apply(r.value, s.value));
+          }
+          else {
+            return r;
+          }
+        },
+        r -> {
+          if (r.value == null) {
+            return Optional.empty();
+          }
+          else {
+            return Optional.of(r.value);
+          }
+        }
+    );
+  }
+
+  static <T> Collector<T, ?, T> reduce(T identity, BinaryOperator<T> reducer) {
+
+    return Collector.of(() -> new Reduction<>(identity),
+        (r, t) -> r.value = reducer.apply(r.value, t),
+        (r, s) -> r.replace(reducer.apply(r.value, s.value)),
+        r -> r.value
+    );
+  }
+
+  static <T, S> Collector<T, ?, S> reduce(S identity,
+      BiFunction<S, ? super T, S> accumulator,
+      BinaryOperator<S> combiner) {
+
+    return Collector.of(() -> new Reduction<>(identity),
+        (r, t) -> r.value = accumulator.apply(r.value, t),
+        (r, s) -> r.replace(combiner.apply(r.value, s.value)),
+        r -> r.value
+    );
+  }
+
+  private static class Reduction<T> {
+    private T value;
+
+    Reduction() {
+    }
+
+    Reduction(T value) {
+      this.value = value;
+    }
+
+    Reduction<T> replace(T newValue) {
+      this.value = newValue;
+      return this;
+    }
+  }
+
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Reductions.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/Reductions.java
@@ -27,7 +27,7 @@ import java.util.stream.Collector;
 /**
  * Reduction utilities that convert arguments supplied to reduce methods on the builders to Collectors.
  */
-class Reductions {
+final class Reductions {
 
   private Reductions() {
   }
@@ -54,14 +54,7 @@ class Reductions {
             return r;
           }
         },
-        r -> {
-          if (r.value == null) {
-            return Optional.empty();
-          }
-          else {
-            return Optional.of(r.value);
-          }
-        }
+        r -> Optional.ofNullable(r.value)
     );
   }
 

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
@@ -34,13 +34,27 @@ import org.eclipse.microprofile.reactive.streams.spi.Stage;
  * @param <R> The type of the result that this subscriber emits.
  * @see ReactiveStreams
  */
-public final class SubscriberBuilder<T, R> extends ReactiveStreamsBuilder<SubscriberWithResult<T, R>> {
+public final class SubscriberBuilder<T, R> extends ReactiveStreamsBuilder {
 
-  SubscriberBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+  SubscriberBuilder(Stage stage, ReactiveStreamsBuilder previous) {
     super(stage, previous);
   }
 
-  @Override
+  /**
+   * Build this stream, using the first {@link ReactiveStreamsEngine} found by the {@link java.util.ServiceLoader}.
+   *
+   * @return A {@link SubscriberWithResult} that will run this stream.
+   */
+  public SubscriberWithResult<T, R> build() {
+    return build(defaultEngine());
+  }
+
+  /**
+   * Build this stream, using the supplied {@link ReactiveStreamsEngine}.
+   *
+   * @param engine The engine to run the stream with.
+   * @return A {@link SubscriberWithResult} that will run this stream.
+   */
   public SubscriberWithResult<T, R> build(ReactiveStreamsEngine engine) {
     return engine.buildSubscriber(toGraph(true, false));
   }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+
+/**
+ * A builder for a {@link org.reactivestreams.Subscriber} and its result.
+ * <p>
+ * When built, this builder returns a {@link SubscriberWithResult}, which encapsulates both a
+ * {@link org.reactivestreams.Subscriber} and a {@link java.util.concurrent.CompletionStage} that will be redeemed
+ * with the result produced by the subscriber when the stream completes normally, or will be redeemed with an error
+ * if the subscriber receives an error.
+ *
+ * @param <T> The type of the elements that this subscriber consumes.
+ * @param <R> The type of the result that this subscriber emits.
+ * @see ReactiveStreams
+ */
+public final class SubscriberBuilder<T, R> extends ReactiveStreamsBuilder<SubscriberWithResult<T, R>> {
+
+  SubscriberBuilder(Stage stage, ReactiveStreamsBuilder<?> previous) {
+    super(stage, previous);
+  }
+
+  @Override
+  public SubscriberWithResult<T, R> build(ReactiveStreamsEngine engine) {
+    return engine.buildSubscriber(toGraph(true, false));
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberWithResult.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberWithResult.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.reactivestreams.Subscriber;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A subscriber with a result.
+ * <p>
+ * The result is provided through a {@link CompletionStage}, which is redeemed when the subscriber receives a
+ * completion or error signal, or otherwise cancels the stream.
+ *
+ * @param <T> The type of the elements that the subscriber consumes.
+ * @param <R> The type of the result that the subscriber emits.
+ */
+public final class SubscriberWithResult<T, R> {
+  private final Subscriber<T> subscriber;
+  private final CompletionStage<R> result;
+
+  public SubscriberWithResult(Subscriber<T> subscriber, CompletionStage<R> result) {
+    this.subscriber = subscriber;
+    this.result = result;
+  }
+
+  /**
+   * Get the subscriber.
+   *
+   * @return The subscriber.
+   */
+  public Subscriber<T> getSubscriber() {
+    return subscriber;
+  }
+
+  /**
+   * Get the result.
+   *
+   * @return The result.
+   */
+  public CompletionStage<R> getResult() {
+    return result;
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberWithResult.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberWithResult.java
@@ -46,7 +46,7 @@ public final class SubscriberWithResult<T, R> {
    *
    * @return The subscriber.
    */
-  public Subscriber<T> getSubscriber() {
+  public Subscriber<T> getRsSubscriber() {
     return subscriber;
   }
 

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/package-info.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/package-info.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * Reactive streams support.
+ * <p>
+ * This provides utilities for building stream graphs that consume or produce elements using the
+ * {@link org.reactivestreams.Publisher}, {@link org.reactivestreams.Subscriber} and
+ * {@link org.reactivestreams.Processor} interfaces.
+ * <p>
+ * There are four primary classes used for building these graphs:
+ *
+ * <ul>
+ * <li>{@link PublisherBuilder}, which when built produces a {@link org.reactivestreams.Publisher}</li>
+ * <li>{@link SubscriberBuilder}, which when built produces a {@link SubscriberWithResult}</li>
+ * <li>{@link ProcessorBuilder}, which when built produces a {@link org.reactivestreams.Processor}</li>
+ * <li>{@link CompletionBuilder}, which when built produces a {@link java.util.concurrent.CompletionStage}</li>
+ * </ul>
+ * <p>
+ * Operations on these builders may change the shape of the builder, for example, {@link ProcessorBuilder#toList()}
+ * changes the builder to a {@link SubscriberBuilder}, since the processor now has a termination stage to direct its
+ * elements to.
+ * <p>
+ * {@link SubscriberBuilder}'s are a special case, in that they don't just build a
+ * {@link org.reactivestreams.Subscriber}, they build a {@link SubscriberWithResult}, which encapsulates both a
+ * {@link org.reactivestreams.Subscriber} and a {@link java.util.concurrent.CompletionStage} of the result of the
+ * subscriber processing. This {@link java.util.concurrent.CompletionStage} will be redeemed with a result when the
+ * stream terminates normally, or if the stream terminates with an error, will be redeemed with an error. The result is
+ * specific to whatever the {@link org.reactivestreams.Subscriber} does, for example, in the case of
+ * {@link ProcessorBuilder#toList()}, the result will be a {@link java.util.List} of all the elements produced by the
+ * {@link org.reactivestreams.Processor}, while in the case of {@link ProcessorBuilder#findFirst()}, it's an
+ * {@link java.util.Optional} of the first element of the stream. In some cases, there is no result, in which case the
+ * result is the {@link Void} type, and the {@link java.util.concurrent.CompletionStage} is only useful for signalling
+ * normal or error termination of the stream.
+ * <p>
+ * The {@link CompletionBuilder} builds a closed graph, in that case both a {@link org.reactivestreams.Publisher}
+ * and {@link org.reactivestreams.Subscriber} have been provided, and building the graph will run it and return
+ * the result of the {@link org.reactivestreams.Subscriber} as a {@link java.util.concurrent.CompletionStage}.
+ * <p>
+ * An example use of this API is perhaps you have a {@link org.reactivestreams.Publisher} of rows from a database,
+ * and you want to output it as a comma separated list of lines to publish to an HTTP client request body, which
+ * expects a {@link org.reactivestreams.Publisher} of {@link java.nio.ByteBuffer}. Here's how this might be implemented:
+ *
+ * <pre>
+ *   Publisher&lt;Row&gt; rowsPublisher = ...;
+ *
+ *   Publisher&lt;ByteBuffer&gt; bodyPublisher =
+ *     // Create a publisher builder from the rows publisher
+ *     ReactiveStreams.fromPublisher(rowsPublisher)
+ *       // Map the rows to CSV strings
+ *       .map(row -&gt;
+ *         String.format("%s, %s, %d\n", row.getString("firstName"),
+ *           row.getString("lastName"), row.getInt("age))
+ *       )
+ *       // Convert to ByteBuffer
+ *       .map(line -&gt; ByteBuffer.wrap(line.getBytes("utf-8")))
+ *       // Build the publisher
+ *       .build();
+ *
+ *   // Make the request
+ *   HttpClient client = HttpClient.newHttpClient();
+ *   client.send(
+ *     HttpRequest
+ *       .newBuilder(new URI("http://www.foo.com/"))
+ *       .POST(BodyProcessor.fromPublisher(bodyPublisher))
+ *       .build()
+ *   );
+ * </pre>
+ * <p>
+ * Reactive streams support.
+ * <p>
+ * This provides utilities for building stream graphs that consume or produce elements using the
+ * {@link org.reactivestreams.Publisher}, {@link org.reactivestreams.Subscriber} and
+ * {@link org.reactivestreams.Processor} interfaces.
+ * <p>
+ * There are four primary classes used for building these graphs:
+ *
+ * <ul>
+ * <li>{@link PublisherBuilder}, which when built produces a {@link org.reactivestreams.Publisher}</li>
+ * <li>{@link SubscriberBuilder}, which when built produces a {@link SubscriberWithResult}</li>
+ * <li>{@link ProcessorBuilder}, which when built produces a {@link org.reactivestreams.Processor}</li>
+ * <li>{@link CompletionBuilder}, which when built produces a {@link java.util.concurrent.CompletionStage}</li>
+ * </ul>
+ * <p>
+ * Operations on these builders may change the shape of the builder, for example, {@link ProcessorBuilder#toList()}
+ * changes the builder to a {@link SubscriberBuilder}, since the processor now has a termination stage to direct its
+ * elements to.
+ * <p>
+ * {@link SubscriberBuilder}'s are a special case, in that they don't just build a
+ * {@link org.reactivestreams.Subscriber}, they build a {@link SubscriberWithResult}, which encapsulates both a
+ * {@link org.reactivestreams.Subscriber} and a {@link java.util.concurrent.CompletionStage} of the result of the
+ * subscriber processing. This {@link java.util.concurrent.CompletionStage} will be redeemed with a result when the
+ * stream terminates normally, or if the stream terminates with an error, will be redeemed with an error. The result is
+ * specific to whatever the {@link org.reactivestreams.Subscriber} does, for example, in the case of
+ * {@link ProcessorBuilder#toList()}, the result will be a {@link java.util.List} of all the elements produced by the
+ * {@link org.reactivestreams.Processor}, while in the case of {@link ProcessorBuilder#findFirst()}, it's an
+ * {@link java.util.Optional} of the first element of the stream. In some cases, there is no result, in which case the
+ * result is the {@link Void} type, and the {@link java.util.concurrent.CompletionStage} is only useful for signalling
+ * normal or error termination of the stream.
+ * <p>
+ * The {@link CompletionBuilder} builds a closed graph, in that case both a {@link org.reactivestreams.Publisher}
+ * and {@link org.reactivestreams.Subscriber} have been provided, and building the graph will run it and return
+ * the result of the {@link org.reactivestreams.Subscriber} as a {@link java.util.concurrent.CompletionStage}.
+ * <p>
+ * An example use of this API is perhaps you have a {@link org.reactivestreams.Publisher} of rows from a database,
+ * and you want to output it as a comma separated list of lines to publish to an HTTP client request body, which
+ * expects a {@link org.reactivestreams.Publisher} of {@link java.nio.ByteBuffer}. Here's how this might be implemented:
+ *
+ * <pre>
+ *   Publisher&lt;Row&gt; rowsPublisher = ...;
+ *
+ *   Publisher&lt;ByteBuffer&gt; bodyPublisher =
+ *     // Create a publisher builder from the rows publisher
+ *     ReactiveStreams.fromPublisher(rowsPublisher)
+ *       // Map the rows to CSV strings
+ *       .map(row -&gt;
+ *         String.format("%s, %s, %d\n", row.getString("firstName"),
+ *           row.getString("lastName"), row.getInt("age))
+ *       )
+ *       // Convert to ByteBuffer
+ *       .map(line -&gt; ByteBuffer.wrap(line.getBytes("utf-8")))
+ *       // Build the publisher
+ *       .build();
+ *
+ *   // Make the request
+ *   HttpClient client = HttpClient.newHttpClient();
+ *   client.send(
+ *     HttpRequest
+ *       .newBuilder(new URI("http://www.foo.com/"))
+ *       .POST(BodyProcessor.fromPublisher(bodyPublisher))
+ *       .build()
+ *   );
+ * </pre>
+ * <p>
+ * Reactive streams support.
+ * <p>
+ * This provides utilities for building stream graphs that consume or produce elements using the
+ * {@link org.reactivestreams.Publisher}, {@link org.reactivestreams.Subscriber} and
+ * {@link org.reactivestreams.Processor} interfaces.
+ * <p>
+ * There are four primary classes used for building these graphs:
+ *
+ * <ul>
+ * <li>{@link PublisherBuilder}, which when built produces a {@link org.reactivestreams.Publisher}</li>
+ * <li>{@link SubscriberBuilder}, which when built produces a {@link SubscriberWithResult}</li>
+ * <li>{@link ProcessorBuilder}, which when built produces a {@link org.reactivestreams.Processor}</li>
+ * <li>{@link CompletionBuilder}, which when built produces a {@link java.util.concurrent.CompletionStage}</li>
+ * </ul>
+ * <p>
+ * Operations on these builders may change the shape of the builder, for example, {@link ProcessorBuilder#toList()}
+ * changes the builder to a {@link SubscriberBuilder}, since the processor now has a termination stage to direct its
+ * elements to.
+ * <p>
+ * {@link SubscriberBuilder}'s are a special case, in that they don't just build a
+ * {@link org.reactivestreams.Subscriber}, they build a {@link SubscriberWithResult}, which encapsulates both a
+ * {@link org.reactivestreams.Subscriber} and a {@link java.util.concurrent.CompletionStage} of the result of the
+ * subscriber processing. This {@link java.util.concurrent.CompletionStage} will be redeemed with a result when the
+ * stream terminates normally, or if the stream terminates with an error, will be redeemed with an error. The result is
+ * specific to whatever the {@link org.reactivestreams.Subscriber} does, for example, in the case of
+ * {@link ProcessorBuilder#toList()}, the result will be a {@link java.util.List} of all the elements produced by the
+ * {@link org.reactivestreams.Processor}, while in the case of {@link ProcessorBuilder#findFirst()}, it's an
+ * {@link java.util.Optional} of the first element of the stream. In some cases, there is no result, in which case the
+ * result is the {@link Void} type, and the {@link java.util.concurrent.CompletionStage} is only useful for signalling
+ * normal or error termination of the stream.
+ * <p>
+ * The {@link CompletionBuilder} builds a closed graph, in that case both a {@link org.reactivestreams.Publisher}
+ * and {@link org.reactivestreams.Subscriber} have been provided, and building the graph will run it and return
+ * the result of the {@link org.reactivestreams.Subscriber} as a {@link java.util.concurrent.CompletionStage}.
+ * <p>
+ * An example use of this API is perhaps you have a {@link org.reactivestreams.Publisher} of rows from a database,
+ * and you want to output it as a comma separated list of lines to publish to an HTTP client request body, which
+ * expects a {@link org.reactivestreams.Publisher} of {@link java.nio.ByteBuffer}. Here's how this might be implemented:
+ *
+ * <pre>
+ *   Publisher&lt;Row&gt; rowsPublisher = ...;
+ *
+ *   Publisher&lt;ByteBuffer&gt; bodyPublisher =
+ *     // Create a publisher builder from the rows publisher
+ *     ReactiveStreams.fromPublisher(rowsPublisher)
+ *       // Map the rows to CSV strings
+ *       .map(row -&gt;
+ *         String.format("%s, %s, %d\n", row.getString("firstName"),
+ *           row.getString("lastName"), row.getInt("age))
+ *       )
+ *       // Convert to ByteBuffer
+ *       .map(line -&gt; ByteBuffer.wrap(line.getBytes("utf-8")))
+ *       // Build the publisher
+ *       .build();
+ *
+ *   // Make the request
+ *   HttpClient client = HttpClient.newHttpClient();
+ *   client.send(
+ *     HttpRequest
+ *       .newBuilder(new URI("http://www.foo.com/"))
+ *       .POST(BodyProcessor.fromPublisher(bodyPublisher))
+ *       .build()
+ *   );
+ * </pre>
+ */
+
+/**
+ * Reactive streams support.
+ * <p>
+ * This provides utilities for building stream graphs that consume or produce elements using the
+ * {@link org.reactivestreams.Publisher}, {@link org.reactivestreams.Subscriber} and
+ * {@link org.reactivestreams.Processor} interfaces.
+ * <p>
+ * There are four primary classes used for building these graphs:
+ * <p>
+ * <ul>
+ * <li>{@link PublisherBuilder}, which when built produces a {@link org.reactivestreams.Publisher}</li>
+ * <li>{@link SubscriberBuilder}, which when built produces a {@link SubscriberWithResult}</li>
+ * <li>{@link ProcessorBuilder}, which when built produces a {@link org.reactivestreams.Processor}</li>
+ * <li>{@link CompletionBuilder}, which when built produces a {@link java.util.concurrent.CompletionStage}</li>
+ * </ul>
+ * <p>
+ * Operations on these builders may change the shape of the builder, for example, {@link ProcessorBuilder#toList()}
+ * changes the builder to a {@link SubscriberBuilder}, since the processor now has a termination stage to direct its
+ * elements to.
+ * <p>
+ * {@link SubscriberBuilder}'s are a special case, in that they don't just build a
+ * {@link org.reactivestreams.Subscriber}, they build a {@link SubscriberWithResult}, which encapsulates both a
+ * {@link org.reactivestreams.Subscriber} and a {@link java.util.concurrent.CompletionStage} of the result of the
+ * subscriber processing. This {@link java.util.concurrent.CompletionStage} will be redeemed with a result when the
+ * stream terminates normally, or if the stream terminates with an error, will be redeemed with an error. The result is
+ * specific to whatever the {@link org.reactivestreams.Subscriber} does, for example, in the case of
+ * {@link ProcessorBuilder#toList()}, the result will be a {@link java.util.List} of all the elements produced by the
+ * {@link org.reactivestreams.Processor}, while in the case of {@link ProcessorBuilder#findFirst()}, it's an
+ * {@link java.util.Optional} of the first element of the stream. In some cases, there is no result, in which case the
+ * result is the {@link Void} type, and the {@link java.util.concurrent.CompletionStage} is only useful for signalling
+ * normal or error termination of the stream.
+ * <p>
+ * The {@link CompletionBuilder} builds a closed graph, in that case both a {@link org.reactivestreams.Publisher}
+ * and {@link org.reactivestreams.Subscriber} have been provided, and building the graph will run it and return
+ * the result of the {@link org.reactivestreams.Subscriber} as a {@link java.util.concurrent.CompletionStage}.
+ * <p>
+ * An example use of this API is perhaps you have a {@link org.reactivestreams.Publisher} of rows from a database,
+ * and you want to output it as a comma separated list of lines to publish to an HTTP client request body, which
+ * expects a {@link org.reactivestreams.Publisher} of {@link java.nio.ByteBuffer}. Here's how this might be implemented:
+ * <p>
+ * <pre>
+ *   Publisher&lt;Row&gt; rowsPublisher = ...;
+ *
+ *   Publisher&lt;ByteBuffer&gt; bodyPublisher =
+ *     // Create a publisher builder from the rows publisher
+ *     ReactiveStreams.fromPublisher(rowsPublisher)
+ *       // Map the rows to CSV strings
+ *       .map(row -&gt;
+ *         String.format("%s, %s, %d\n", row.getString("firstName"),
+ *           row.getString("lastName"), row.getInt("age))
+ *       )
+ *       // Convert to ByteBuffer
+ *       .map(line -&gt; ByteBuffer.wrap(line.getBytes("utf-8")))
+ *       // Build the publisher
+ *       .build();
+ *
+ *   // Make the request
+ *   HttpClient client = HttpClient.newHttpClient();
+ *   client.send(
+ *     HttpRequest
+ *       .newBuilder(new URI("http://www.foo.com/"))
+ *       .POST(BodyProcessor.fromPublisher(bodyPublisher))
+ *       .build()
+ *   );
+ * </pre>
+ */
+package org.eclipse.microprofile.reactive.streams;

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Graph.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Graph.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.spi;
+
+import java.util.Collection;
+
+/**
+ * A graph.
+ * <p>
+ * Reactive Streams engines are required to convert the stages of this graph into a stream with interfaces according
+ * to the shape. The shape is governed by whether the graph has an inlet, an outlet, neither or both.
+ */
+public class Graph {
+  private final Collection<Stage> stages;
+  private final boolean hasInlet;
+  private final boolean hasOutlet;
+
+  /**
+   * Create a graph from the given stages.
+   * <p>
+   * The stages of this graph will be validated to ensure that connect properly, that is, every stage but the first
+   * stage must have an inlet to receive a stream from the previous stage, and every stage but the last stage must have
+   * an outlet to produce a stream from the next stage.
+   * <p>
+   * If the first stage has an inlet, then this graph has an inlet, and can therefore be represented as a
+   * {@link org.reactivestreams.Subscriber}. If the last stage has an outlet, then this graph has an outlet, and
+   * therefore can be represented as a {@link org.reactivestreams.Publisher}.
+   *
+   * @param stages The stages.
+   */
+  public Graph(Collection<Stage> stages) {
+
+    boolean hasInlet = true;
+    Stage lastStage = null;
+
+    for (Stage stage : stages) {
+      if (lastStage != null && !lastStage.hasOutlet()) {
+        throw new IllegalStateException("Graph required an outlet from the previous stage " + lastStage + " but none was found.");
+      }
+
+      if (lastStage != null) {
+        if (!stage.hasInlet()) {
+          throw new IllegalStateException("Stage encountered in graph with no inlet after the first stage: " + stage);
+        }
+      }
+      else {
+        hasInlet = stage.hasInlet();
+      }
+
+      lastStage = stage;
+    }
+
+    this.hasInlet = hasInlet;
+    this.hasOutlet = lastStage == null || lastStage.hasOutlet();
+    this.stages = stages;
+  }
+
+  /**
+   * Get the stages of this graph.
+   */
+  public Collection<Stage> getStages() {
+    return stages;
+  }
+
+  /**
+   * Returns true if this graph has an inlet, ie, if this graph can be turned into a
+   * {@link org.reactivestreams.Subscriber}.
+   */
+  public boolean hasInlet() {
+    return hasInlet;
+  }
+
+  /**
+   * Returns true if this graph has an outlet, ie, if this graph can be turned into a
+   * {@link org.reactivestreams.Publisher}.
+   */
+  public boolean hasOutlet() {
+    return hasOutlet;
+  }
+
+  @Override
+  public String toString() {
+    return "Graph{" +
+        "stages=" + stages +
+        '}';
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/ReactiveStreamsEngine.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/ReactiveStreamsEngine.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletionStage;
 /**
  * An engine for turning reactive streams graphs into Reactive Streams publishers/subscribers.
  * <p>
- * The zero argument {@link org.eclipse.microprofile.reactive.streams.ReactiveStreamsBuilder#build()} method will use
+ * The zero argument {@code build} and {@code run} methods on subclasses of this will use
  * the {@link java.util.ServiceLoader} to load an engine for the current context classloader. It does not cache
  * engines between invocations. If instantiating an engine is expensive (eg, it creates threads), then it is
  * recommended that the implementation does its own caching by providing the engine using a static provider method.

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/ReactiveStreamsEngine.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/ReactiveStreamsEngine.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.spi;
+
+
+import org.eclipse.microprofile.reactive.streams.SubscriberWithResult;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * An engine for turning reactive streams graphs into Reactive Streams publishers/subscribers.
+ * <p>
+ * The zero argument {@link org.eclipse.microprofile.reactive.streams.ReactiveStreamsBuilder#build()} method will use
+ * the {@link java.util.ServiceLoader} to load an engine for the current context classloader. It does not cache
+ * engines between invocations. If instantiating an engine is expensive (eg, it creates threads), then it is
+ * recommended that the implementation does its own caching by providing the engine using a static provider method.
+ */
+public interface ReactiveStreamsEngine {
+
+  /**
+   * Build a {@link Publisher} from the given stages.
+   * <p>
+   * The passed in graph will have an outlet and no inlet.
+   *
+   * @param graph The stages to build the publisher from. Will not be empty.
+   * @param <T>   The type of elements that the publisher publishes.
+   * @return A publisher that implements the passed in graph of stages.
+   * @throws UnsupportedStageException If a stage in the stages is not supported by this Reactive Streams engine.
+   */
+  <T> Publisher<T> buildPublisher(Graph graph) throws UnsupportedStageException;
+
+  /**
+   * Build a {@link org.reactivestreams.Subscriber} from the given stages.
+   * <p>
+   * The passed in graph will have an inlet and no outlet.
+   *
+   * @param graph The graph to build the subscriber from. Will not be empty.
+   * @param <T>   The type of elements that the subscriber subscribes to.
+   * @param <R>   The result of subscribing to the stages.
+   * @return A subscriber that implements the passed in graph of stages.
+   * @throws UnsupportedStageException If a stage in the stages is not supported by this Reactive Streams engine.
+   */
+  <T, R> SubscriberWithResult<T, R> buildSubscriber(Graph graph) throws UnsupportedStageException;
+
+  /**
+   * Build a {@link Processor} from the given stages.
+   * <p>
+   * The passed in graph will have an inlet and an outlet.
+   *
+   * @param graph The graph to build the processor from. If empty, then the processor should be an identity processor.
+   * @param <T>   The type of elements that the processor subscribes to.
+   * @param <R>   The type of elements that the processor publishes.
+   * @return A processor that implements the passed in graph of stages.
+   * @throws UnsupportedStageException If a stage in the stages is not supported by this Reactive Streams engine.
+   */
+  <T, R> Processor<T, R> buildProcessor(Graph graph) throws UnsupportedStageException;
+
+  /**
+   * Build a closed graph from the given stages.
+   * <p>
+   * The passed in graph will have no inlet and no outlet.
+   *
+   * @param graph The graph to build the closed graph from. Will not be empty.
+   * @param <T>   The type of the result of running the closed graph.
+   * @return A CompletionStage of the result of running the graph.
+   * @throws UnsupportedStageException If a stage in the stages is not supported by this reactive streams engine.
+   */
+  <T> CompletionStage<T> buildCompletion(Graph graph) throws UnsupportedStageException;
+
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Stage.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Stage.java
@@ -1,0 +1,448 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.spi;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import java.util.Collections;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * A stage of a Reactive Streams graph.
+ * <p>
+ * A Reactive Streams engine will walk a graph of stages to produce {@link Publisher},
+ * {@link Subscriber} and {@link Processor} instances that handle the stream
+ * according to the sequence of stages.
+ */
+public interface Stage {
+
+  /**
+   * Whether this stage has an inlet - ie, when built, will it implement the {@link Subscriber}
+   * interface?
+   *
+   * @return True if this stage has an inlet.
+   */
+  default boolean hasInlet() {
+    return false;
+  }
+
+  /**
+   * Whether this stage has an outlet - ie, when built, will it implement the {@link Publisher}
+   * interface?
+   *
+   * @return True if this stage has an outlet.
+   */
+  default boolean hasOutlet() {
+    return false;
+  }
+
+  /**
+   * Convenience interface for inlet stages.
+   */
+  interface Inlet extends Stage {
+    @Override
+    default boolean hasInlet() {
+      return true;
+    }
+  }
+
+  /**
+   * Convenience interface for outlet stages.
+   */
+  interface Outlet extends Stage {
+    @Override
+    default boolean hasOutlet() {
+      return true;
+    }
+  }
+
+  /**
+   * A map stage.
+   * <p>
+   * The given mapper function should be invoked on each element consumed, and the output of the function should be
+   * emitted.
+   * <p>
+   * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
+   */
+  final class Map implements Inlet, Outlet {
+    private final Function<?, ?> mapper;
+
+    public Map(Function<?, ?> mapper) {
+      this.mapper = mapper;
+    }
+
+    /**
+     * The mapper function.
+     *
+     * @return The mapper function.
+     */
+    public Function<?, ?> getMapper() {
+      return mapper;
+    }
+  }
+
+  /**
+   * A filter stage.
+   * <p>
+   * The given predicate should be supplied when the stream is first run, and then invoked on each element consumed.
+   * If it returns true, the element should be emitted.
+   * <p>
+   * Any {@link RuntimeException} thrown by the predicate should be propagated down the stream as an error.
+   */
+  final class Filter implements Inlet, Outlet {
+    private final Supplier<Predicate<?>> predicate;
+
+    public Filter(Supplier<Predicate<?>> predicate) {
+      this.predicate = predicate;
+    }
+
+    /**
+     * The predicate.
+     *
+     * @return The predicate.
+     */
+    public Supplier<Predicate<?>> getPredicate() {
+      return predicate;
+    }
+  }
+
+  /**
+   * A take while stage.
+   * <p>
+   * The given predicate should be supplied when the stream is first run, and then invoked on each element consumed.
+   * When it returns true, the element should be emitted, when it returns false, the element should only be emitted if
+   * inclusive is true, and then the stream should be completed.
+   * <p>
+   * Any {@link RuntimeException} thrown by the predicate should be propagated down the stream as an error.
+   */
+  final class TakeWhile implements Inlet, Outlet {
+    private final Supplier<Predicate<?>> predicate;
+    private final boolean inclusive;
+
+    public TakeWhile(Supplier<Predicate<?>> predicate, boolean inclusive) {
+      this.predicate = predicate;
+      this.inclusive = inclusive;
+    }
+
+    /**
+     * The predicate.
+     *
+     * @return The predicate.
+     */
+    public Supplier<Predicate<?>> getPredicate() {
+      return predicate;
+    }
+
+    /**
+     * Whether the element that this returns false on should be emitted or not.
+     */
+    public boolean isInclusive() {
+      return inclusive;
+    }
+  }
+
+  /**
+   * A publisher stage.
+   * <p>
+   * The given publisher should be subscribed to whatever subscriber is provided to this graph, via any other subsequent
+   * stages.
+   */
+  final class PublisherStage implements Outlet {
+    private final Publisher<?> publisher;
+
+    public PublisherStage(Publisher<?> publisher) {
+      this.publisher = publisher;
+    }
+
+    /**
+     * The publisher.
+     *
+     * @return The publisher.
+     */
+    public Publisher<?> getPublisher() {
+      return publisher;
+    }
+  }
+
+  /**
+   * A publisher of zero to many values.
+   * <p>
+   * When built, should produce a publisher that produces all the values (until cancelled) emitted by this iterables
+   * iterator, followed by completion of the stream.
+   * <p>
+   * Any exceptions thrown by the iterator must be propagated downstream.
+   */
+  final class Of implements Outlet {
+    private final Iterable<?> elements;
+
+    public Of(Iterable<?> elements) {
+      this.elements = elements;
+    }
+
+    /**
+     * The elements to emit.
+     *
+     * @return The elements to emit.
+     */
+    public Iterable<?> getElements() {
+      return elements;
+    }
+
+    public static final Of EMPTY = new Of(Collections.emptyList());
+  }
+
+  /**
+   * A processor stage.
+   * <p>
+   * When built, should connect upstream of the graph to the inlet of this processor, and downstream to the outlet.
+   */
+  final class ProcessorStage implements Inlet, Outlet {
+    private final Processor<?, ?> processor;
+
+    public ProcessorStage(Processor<?, ?> processor) {
+      this.processor = processor;
+    }
+
+    /**
+     * The processor.
+     *
+     * @return The processor.
+     */
+    public Processor<?, ?> getProcessor() {
+      return processor;
+    }
+  }
+
+  /**
+   * A subscriber stage that emits the first element encountered.
+   * <p>
+   * When built, the {@link CompletionStage} should emit an {@link java.util.Optional} of the first
+   * element emitted. If no element is emitted before completion of the stream, it should emit an empty optional. Once
+   * the element has been emitted, the stream should be cancelled if not already complete.
+   * <p>
+   * If an error is emitted before the first element is encountered, the stream must redeem the completion stage with
+   * that error.
+   */
+  final class FindFirst implements Inlet {
+    private FindFirst() {
+    }
+
+    public static final FindFirst INSTANCE = new FindFirst();
+  }
+
+  /**
+   * A subscriber.
+   * <p>
+   * When built, the {@link CompletionStage} should emit <code>null</code> when the stream
+   * completes normally, or an error if the stream terminates with an error.
+   * <p>
+   * Implementing this will typically require inserting a handler before the subscriber that listens for errors.
+   */
+  final class SubscriberStage implements Inlet {
+    private final Subscriber<?> subscriber;
+
+    public SubscriberStage(Subscriber<?> subscriber) {
+      this.subscriber = subscriber;
+    }
+
+    /**
+     * The subscriber.
+     *
+     * @return The subscriber.
+     */
+    public Subscriber<?> getSubscriber() {
+      return subscriber;
+    }
+  }
+
+  /**
+   * A collect stage.
+   * <p>
+   * This should use the collectors supplier to create an accumulated value, and then the accumulator BiConsumer should
+   * be used to accumulate the received elements in the value. Finally, the returned
+   * {@link CompletionStage} should be redeemed by value returned by the finisher function applied
+   * to the accumulated value when the stream terminates normally, or should be redeemed with an error if the stream
+   * terminates with an error.
+   * <p>
+   * If the collector throws an exception, the stream must be cancelled, and the
+   * {@link CompletionStage} must be redeemed with that error.
+   */
+  final class Collect implements Inlet {
+    private final Collector<?, ?, ?> collector;
+
+    public Collect(Collector<?, ?, ?> collector) {
+      this.collector = collector;
+    }
+
+    /**
+     * The collector.
+     *
+     * @return The collector.
+     */
+    public Collector<?, ?, ?> getCollector() {
+      return collector;
+    }
+  }
+
+  /**
+   * A flat map stage.
+   * <p>
+   * The flat map stage should execute the given mapper on each element, and concatenate the publishers emitted by
+   * the mapper function into the resulting stream.
+   * <p>
+   * The graph emitted by the mapper function is guaranteed to have an outlet but no inlet.
+   * <p>
+   * The engine must be careful to ensure only one publisher emitted by the mapper function is running at a time.
+   */
+  final class FlatMap implements Inlet, Outlet {
+    private final Function<?, Graph> mapper;
+
+    public FlatMap(Function<?, Graph> mapper) {
+      this.mapper = mapper;
+    }
+
+    /**
+     * The mapper function.
+     *
+     * @return The mapper function.
+     */
+    public Function<?, Graph> getMapper() {
+      return mapper;
+    }
+  }
+
+  /**
+   * A flat map stage that emits and flattens {@link CompletionStage}.
+   * <p>
+   * The flat map stage should execute the given mapper on each element, and concatenate the values redeemed by the
+   * {@link CompletionStage}'s emitted by the mapper function into the resulting stream.
+   * <p>
+   * The engine must be careful to ensure only one mapper function is executed at a time, with the next mapper function
+   * not executing until the {@link CompletionStage} returned by the previous mapper function has been redeemed.
+   */
+  final class FlatMapCompletionStage implements Inlet, Outlet {
+    private final Function<?, CompletionStage<?>> mapper;
+
+    public FlatMapCompletionStage(Function<?, CompletionStage<?>> mapper) {
+      this.mapper = mapper;
+    }
+
+    /**
+     * The mapper function.
+     *
+     * @return The mapper function.
+     */
+    public Function<?, CompletionStage<?>> getMapper() {
+      return mapper;
+    }
+  }
+
+  /**
+   * A flat map stage that emits and fattens {@link Iterable}.
+   * <p>
+   * The flat map stage should execute the given mapper on each element, and concatenate the iterables emitted by
+   * the mapper function into the resulting stream.
+   */
+  final class FlatMapIterable implements Inlet, Outlet {
+    private final Function<?, Iterable<?>> mapper;
+
+    public FlatMapIterable(Function<?, Iterable<?>> mapper) {
+      this.mapper = mapper;
+    }
+
+    /**
+     * The mapper function.
+     *
+     * @return The mapper function.
+     */
+    public Function<?, Iterable<?>> getMapper() {
+      return mapper;
+    }
+  }
+
+  /**
+   * A failed publisher.
+   * <p>
+   * When built, this should produce a publisher that immediately fails the stream with the passed in error.
+   */
+  final class Failed implements Outlet {
+    private final Throwable error;
+
+    public Failed(Throwable error) {
+      this.error = error;
+    }
+
+    public Throwable getError() {
+      return error;
+    }
+  }
+
+  /**
+   * Concatenate the given graphs together.
+   * <p>
+   * Each graph must have an outlet and no inlet.
+   * <p>
+   * The resulting publisher produced by the concat stage must emit all the elements from the first graph,
+   * and once that graph emits a completion signal, it must then subscribe to and emit all the elements from
+   * the second. If an error is emitted by the either graph, the error should be emitted from the resulting stream.
+   * <p>
+   * If processing terminates early while the first graph is still emitting, either due to that graph emitting an
+   * error, or due to a cancellation signal from downstream, then the second graph must be subscribed to and cancelled.
+   * This is to ensure that any hot publishers that may be backing the graphs are cleaned up.
+   */
+  final class Concat implements Outlet {
+    private final Graph first;
+    private final Graph second;
+
+    public Concat(Graph first, Graph second) {
+      this.first = validate(first);
+      this.second = validate(second);
+    }
+
+    private static Graph validate(Graph graph) {
+      if (graph.hasInlet() || !graph.hasOutlet()) {
+        throw new IllegalArgumentException(
+            "Concatenated graphs must have an outlet, but no inlet, but this graph does not: " + graph);
+      }
+      return graph;
+    }
+
+    public Graph getFirst() {
+      return first;
+    }
+
+    public Graph getSecond() {
+      return second;
+    }
+  }
+
+  final class Cancel implements Inlet {
+    private Cancel() {
+    }
+
+    public final static Cancel INSTANCE = new Cancel();
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Stage.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Stage.java
@@ -182,7 +182,7 @@ public interface Stage {
      *
      * @return The publisher.
      */
-    public Publisher<?> getPublisher() {
+    public Publisher<?> getRsPublisher() {
       return publisher;
     }
   }
@@ -231,7 +231,7 @@ public interface Stage {
      *
      * @return The processor.
      */
-    public Processor<?, ?> getProcessor() {
+    public Processor<?, ?> getRsProcessor() {
       return processor;
     }
   }
@@ -273,7 +273,7 @@ public interface Stage {
      *
      * @return The subscriber.
      */
-    public Subscriber<?> getSubscriber() {
+    public Subscriber<?> getRsSubscriber() {
       return subscriber;
     }
   }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/UnsupportedStageException.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/UnsupportedStageException.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.spi;
+
+/**
+ * Exception thrown when a reactive streams engine doesn't support a stage that is passed to it.
+ * <p>
+ * All reactive streams engines should support all stages, but this allows for a graceful mechanism to report issues,
+ * for example if in a future version a new stage is added that is not recognised by an existing implementation.
+ */
+public class UnsupportedStageException extends RuntimeException {
+  public UnsupportedStageException(Stage stage) {
+    super("The " + stage.getClass().getSimpleName() + " stage is not supported by this Reactive Streams engine.");
+  }
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/package-info.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/package-info.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * The Reactive Streams utils SPI.
+ * <p>
+ * Implementors are expected to implement the {@code ReactiveStreamsEngine} interface, and use this SPI to inspect
+ * the graph of stages.
+ * <p>
+ * A TCK is also provided that validates that an implementation is both correct according to this specification, and
+ * the Reactive Streams specification.
+ * <p>
+ * The Reactive Streams utils SPI.
+ * <p>
+ * Implementors are expected to implement the {@code ReactiveStreamsEngine} interface, and use this SPI to inspect
+ * the graph of stages.
+ * <p>
+ * A TCK is also provided that validates that an implementation is both correct according to this specification, and
+ * the Reactive Streams specification.
+ * <p>
+ * The Reactive Streams utils SPI.
+ * <p>
+ * Implementors are expected to implement the {@code ReactiveStreamsEngine} interface, and use this SPI to inspect
+ * the graph of stages.
+ * <p>
+ * A TCK is also provided that validates that an implementation is both correct according to this specification, and
+ * the Reactive Streams specification.
+ */
+
+/**
+ * The Reactive Streams utils SPI.
+ *
+ * Implementors are expected to implement the {@code ReactiveStreamsEngine} interface, and use this SPI to inspect
+ * the graph of stages.
+ *
+ * A TCK is also provided that validates that an implementation is both correct according to this specification, and
+ * the Reactive Streams specification.
+ */
+package org.eclipse.microprofile.reactive.streams.spi;

--- a/streams/checkstyle.xml
+++ b/streams/checkstyle.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<module name="Checker">
+    <module name="SuppressionCommentFilter" />
+    <module name="FileLength">
+        <property name="max" value="3500" />
+        <property name="fileExtensions" value="java" />
+    </module>
+    <module name="FileTabCharacter" />
+    <module name="TreeWalker">
+        <module name="FileContentsHolder" />
+        <module name="ConstantName">
+            <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$" />
+        </module>
+        <module name="LocalVariableName" />
+        <module name="MethodName">
+            <property name="format" value="^_?[a-z][a-zA-Z0-9]*$" />
+        </module>
+        <module name="PackageName" />
+        <module name="LocalFinalVariableName" />
+        <module name="ParameterName" />
+        <module name="StaticVariableName" />
+
+        <module name="TypeName">
+            <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo" />
+        </module>
+        <module name="AvoidStarImport">
+            <property name="excludes" value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context" />
+        </module>
+        <module name="IllegalImport" />
+        <module name="RedundantImport" />
+        <module name="UnusedImports" />
+        <module name="LineLength">
+            <property name="max" value="150" />
+            <property name="ignorePattern" value="@version|@see" />
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="250" />
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="11" />
+        </module>
+        <module name="EmptyBlock">
+            <property name="option" value="text" />
+        </module>
+        <module name="NeedBraces" />
+        <module name="LeftCurly">
+            <property name="option" value="EOL" />
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="ALONE" />
+        </module>
+        <module name="EmptyStatement" />
+        <module name="EqualsHashCode" />
+        <module name="DefaultComesLast" />
+        <module name="MissingSwitchDefault" />
+        <module name="FallThrough" />
+        <module name="MultipleVariableDeclarations" />
+        <module name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck">
+            <property name="severity" value="ignore" />
+        </module>
+        <module name="HideUtilityClassConstructor" />
+        <module name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck">
+            <property name="packageAllowed" value="false" />
+            <property name="protectedAllowed" value="true" />
+            <property name="publicMemberPattern" value="^serialVersionUID" />
+            <property name="severity" value="warning" />
+        </module>
+        <module name="UpperEll" />
+    </module>
+</module>

--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+    <artifactId>microprofile-reactive-streams-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>MicroProfile Reactive Streams</name>
+    <description>Eclipse MicroProfile Reactive Streams Support :: Parent POM</description>
+    <url>http://microprofile.io</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <links>https://osgi.org/javadoc/r6/annotation/</links>
+        
+        <checkstyle.version>2.17</checkstyle.version>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+    
+    <organization>
+        <name>Eclipse Foundation</name>
+        <url>http://www.eclipse.org/</url>
+    </organization>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/eclipse/microprofile-reactive/issues</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <name>James Roper</name>
+            <url>https://jazzy.id.au</url>
+            <organization>Lightbend</organization>
+            <organizationUrl>https://www.lightbend.com</organizationUrl>
+        </developer>    
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse/microprofile-reactive.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse/microprofile-reactive.git</developerConnection>
+        <url>https://github.com/eclipse/microprofile-reactive</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <name>Sonatype OSSRH - Release Staging Area</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>Sonatype OSSRH Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <uniqueVersion>true</uniqueVersion>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <modules>
+        <module>api</module>
+        <module>tck</module>
+        <module>spec</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams</artifactId>
+                <version>1.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams-tck</artifactId>
+                <version>1.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.annotation.versioning</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.eclipse.org</id>
+            <name>Project Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/groups/cbi/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>microprofile.repo.eclipse.org</id>
+            <name>Microprofile Project Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/groups/microprofile/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                    <configuration>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <localCheckout>true</localCheckout>
+                        <arguments>${arguments} -Prelease -Drevremark=${revremark}</arguments>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                    <artifactId>eclipse-jarsigner-plugin</artifactId>
+                    <version>1.1.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${checkstyle.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.microprofile.maven</groupId>
+                <artifactId>microprofile-maven-build-extension</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify-style</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failOnViolation>true</failOnViolation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>true</linkXRef>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <configLocation>checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <version>0.12</version>
+                <executions>
+                    <execution>
+                        <id>rat-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>.travis.yml.*</exclude>
+                        <exclude>bnd.bnd</exclude>
+                        <exclude>*.log</exclude>
+                        <exclude>.checkstyle</exclude>
+                        <exclude>.factorypath</exclude>
+                        <exclude>.editorconfig</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+    
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                         <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <serverId>ossrh</serverId>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+</profiles>
+</project>

--- a/streams/site.yaml
+++ b/streams/site.yaml
@@ -1,0 +1,41 @@
+#######################################################################
+## Copyright (c) 2018 Contributors to the Eclipse Foundation
+##
+## See the NOTICE file(s) distributed with this work for additional
+## information regarding copyright ownership.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+#######################################################################
+%YAML 1.2
+---
+documentation:
+  - title: Configuration for Microprofile
+    file: spec/src/main/asciidoc/microprofile-config-spec.asciidoc
+
+  - title: Architecture
+    file: spec/src/main/asciidoc/architecture.asciidoc
+
+  - title: Configuration Usage Examples
+    file: spec/src/main/asciidoc/configexamples.asciidoc
+
+  - title: Accessing or Creating a certain Configuration
+    file: spec/src/main/asciidoc/configprovider.asciidoc
+
+  - title: ConfigSources
+    file: spec/src/main/asciidoc/configsources.asciidoc
+
+  - title: Converter
+    file: spec/src/main/asciidoc/converters.asciidoc
+
+  - title: License
+    file: spec/src/main/asciidoc/license-alv2.asciidoc

--- a/streams/site.yaml
+++ b/streams/site.yaml
@@ -19,23 +19,14 @@
 %YAML 1.2
 ---
 documentation:
-  - title: Configuration for Microprofile
-    file: spec/src/main/asciidoc/microprofile-config-spec.asciidoc
+  - title: Reactive Streams Support for Microprofile
+    file: spec/src/main/asciidoc/microprofile-reactive-streams-spec.asciidoc
 
   - title: Architecture
     file: spec/src/main/asciidoc/architecture.asciidoc
 
-  - title: Configuration Usage Examples
-    file: spec/src/main/asciidoc/configexamples.asciidoc
-
-  - title: Accessing or Creating a certain Configuration
-    file: spec/src/main/asciidoc/configprovider.asciidoc
-
-  - title: ConfigSources
-    file: spec/src/main/asciidoc/configsources.asciidoc
-
-  - title: Converter
-    file: spec/src/main/asciidoc/converters.asciidoc
+  - title: Usage Examples
+    file: spec/src/main/asciidoc/examples.asciidoc
 
   - title: License
     file: spec/src/main/asciidoc/license-alv2.asciidoc

--- a/streams/spec/pom.xml
+++ b/streams/spec/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+        <artifactId>microprofile-reactive-streams-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+    <artifactId>microprofile-reactive-streams-spec</artifactId>
+    <packaging>pom</packaging>
+    <name>MicroProfile Reactive Streams Specification</name>
+    <description>MicroProfile Reactive Streams :: Specification</description>
+
+    <properties>
+        <asciidoctor-maven.version>1.5.5</asciidoctor-maven.version>
+        <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
+        <license>Apache License v 2.0</license>
+        <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
+        <revisiondate>${maven.build.timestamp}</revisiondate>
+        <revremark>Draft</revremark>
+    </properties>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor-maven.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>${asciidoctorj-pdf.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>generate-pdf-doc</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${revremark}</revremark>
+                                <revdate>${revisiondate}</revdate>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-html</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${revremark}</revremark>
+                                <revdate>${revisiondate}</revdate>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDocumentName>microprofile-reactive-streams-spec.asciidoc</sourceDocumentName>
+                    <sourceHighlighter>coderay</sourceHighlighter>
+                    <attributes>
+                        <license>Apache License v2.0</license>
+                    </attributes>
+                </configuration>
+            </plugin>
+        </plugins>
+</build>
+    
+
+</project>

--- a/streams/spec/src/main/asciidoc/architecture.asciidoc
+++ b/streams/spec/src/main/asciidoc/architecture.asciidoc
@@ -1,0 +1,128 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[reactivestreamsarchitecture]]
+== Architecture
+
+This specification defines an API for manipulating Reactive Streams, providing operators such as `map`, `filter`, `flatMap`, in a similar fashion to the `java.util.streams` API introduced in Java 8.
+It also provides an SPI for implementing and providing custom Reactive Streams engines, allowing application developers to use whichever engine they see fit.
+
+=== Rationale
+
+The `java.util.streams` API provides functionality necessary for manipulating streams in memory.
+However, manipulating potentially infinite asynchronous streams has some very different requirements which the `java.util.streams` API is not suitable for.
+
+Reactive Streams is a specification for asynchronous streaming between different streaming libraries and/or technologies, which is included in JDK9 as the `java.util.concurrent.Flow` spec.
+Reactive Streams itself however is an SPI for library and technology vendors to implement, it is not intended that application developers implement it as the semantics are very complex.
+
+Commonly, Reactive Streams requires more than just plumbing publishers to subscribers, the stream typically needs to be manipulated in some way, such as applying operations such as `map`, `filter` and `flatMap`.
+Neither Reactive Streams, nor the JDK, provides an API for doing these manipulations.
+Since users are not meant to implement Reactive Streams themselves, this means the only way to do these manipulations currently is to depend on a third party library, such as https://doc.akka.io/docs/akka/current/stream/index.html[Akka Streams], https://github.com/ReactiveX/RxJava[RxJava] or https://projectreactor.io/[Reactor].
+
+This API seeks to fill that gap, so that MicroProfile application developers can manipulate Reactive Streams without bringing in a third party dependency.
+By itself, this API is not interesting to MicroProfile, but with the addition of other Reactive features, such as the MicroProfile Reactive Messaging proposal, it is essential.
+
+There are a number of different approaches to handling the cross cutting concerns relating to actually running streams.
+These include how and whether context is propagated, concurrency models, buffering, hooks for monitoring and remoting.
+Different implementations of Reactive Streams offer different approaches based on varying opinions on how these cross cutting concerns should be treated.
+For this reason, this API provides an underlying SPI to allow different engines to be plugged in to actually run the streams.
+Implementors of this spec will provide a default implementation, however users can select to use a custom implementation if they need.
+
+This specification started as a proposal for the JDK, but after discussions there, it was decided that the JDK was not the right place to incubate such an API.
+It is the intention that once incubated in MicroProfile, this specification will be put to the JDK again as a proposal.
+
+=== Reactive Streams API dependency
+
+Reactive Streams has been included in the JDK9 as the `java.util.concurrent.Flow` API, which contains the `Publisher`, `Subscriber`, `Subscription` and `Processor` interfaces as nested interfaces of `Flow`.
+MicroProfile however is not ready to move to a baseline requirement for JDK9 or above.
+
+For this reason, this proposal uses the JDK6 compatible `org.reactivestreams` API, which provides identical `Publisher`, `Subscriber`, `Subscription` and `Processor` interfaces as members of the `org.reactivestreams` package.
+This dependency contains nothing but those interfaces.
+
+It has been discussed that MicroProfile could copy those interfaces itself, so as to not add this dependency, however this would most likely frustrate use of Reactive Streams in MicroProfile.
+There is a large ecosystem built around the `org.reactivestreams` interfaces.
+If application developers wanted to leverage that ecosystem in their application, they would have to write adapters to bridge the two APIs.
+Given that the `org.reactivestreams` dependency is a jar that contains only these interfaces, identical to the interfaces in JDK9, there doesn't seem to be any value in copying them again into MicroProfile.
+
+To facilitate an eventual migration to the JDK9 interfaces, once MicroProfile adopts JDK9 or later as a baseline JDK version, all methods that pass `org.reactivestreams` interfaces to the user (either as a return value, or by virtue of a user providing a callback to the method to receive it) will have `Rs` added to their name.
+For example, `getSubscriber` will be called `getRsSubscriber`.
+This will allow new methods to be added in future that return `java.util.concurrent.Flow` interfaces, without the `Rs` in the name, allowing the existing `Rs` methods to be kept for a limited time for backwards compatibility.
+Methods that accept a `org.reactivestreams` interface do not need to be given the same treatment, as support for the JDK9 interfaces can be added by overloading them, with backwards compatibility being maintained.
+
+=== Design
+
+==== API
+
+The design of MicroProfile Reactive Streams is centered around builders for the various shapes of streams.
+There are four different shapes of streams that can be built:
+
+* Processors. A processor has an inlet and an outlet, and is represented as a Reactive Streams `Processor` when built. This is called a `ProcessorBuilder`.
+* Publishers. A publisher has an outlet but no inlet, and is represented as a Reactive Streams `Publisher` when built. This is called a `PublisherBuilder`
+* Subscribers. A subscriber has an inlet but no outlet, and it also has a result. It is represented as a product of a Reactive Streams `Subscriber` and a `CompletionStage` that is redeemed with the result, or error if the stream fails, when built. This is called a `SubscriberBuilder`.
+* Closed graphs. A closed graph has no inlet or outlet, both having being provided in during the construction of the graph. It is represented as a `CompletionStage` of the result of the stream, when built. This is called a `CompletionBuilder`.
+
+While building a stream, the stream may change shape during its construction.
+For example, a publisher may be collected into a `List` of elements.
+When this happens, the stream becomes a closed graph, since there is no longer an outlet, but just a result, the result being the `List` of elements:
+
+[source, java]
+----
+PublisherBuilder<Integer> intsPublisher =
+  ReactiveStreams.of(1, 2, 3); <1>
+
+CompletionBuilder<List<Integer>> intsResult =
+  intsPublisher.toList(); <2>
+----
+<1> A publisher of integers 1, 2 and 3.
+<2> A closed graph that emits all the received integers as a result.
+
+
+Or, a processor may be plumbed to a subscriber, in which case, the resulting builder is now a subscriber:
+
+[source, java]
+----
+ProcessorBuilder<Integer, String> toStringProcessor =
+  ReactiveStreams.<Integer>builder()
+    .map(Integer::toString); <1>
+
+SubscriberBuilder<Integer, List<String>> =
+  toStringProcessor.toList(); <2>
+----
+<1> A processor that receives integers and emits them as strings.
+<2> A subscriber that receives integers, and emits all the integers as Strings in a List when the stream completes.
+
+When MicroProfile specifications provide an API that uses Reactive Streams, it is intended that application developers can return and pass the builder interfaces directly to the MicroProfile APIs.
+In many cases, application developers will not need to run the streams themselves.
+However, should they need to run the streams directly themselves, they can do so by using the streams `build` or `run` methods. `PublisherBuilder`, `SubscriberBuilder` and `ProcessorBuilder` all provide a `build` method that returns a `Publisher`, `SubscriberWithResult` and `Processor` respectively, while `CompletionBuilder`, since building it will actually run the stream, provides a `run` method that returns a `CompletionStage`.
+
+The `build` and `run` methods both provide a zero arg variant, which uses the default Reactive Streams engine provided by the platform, as well as a overload that takes a `ReactiveStreamsEngine`, allowing application developers to use a custom engine when they please.
+
+==== SPI
+
+The API is responsible for building graphs of stages.
+The stages form an SPI for `ReactiveStreamsEngine` implementations to build into a running stream.
+Examples of stages include:
+
+* Map
+* Filter
+* Elements to publish
+* Collect
+* Instances of Reactive Streams `Publisher`, `Subscriber` and `Processor`
+
+Each stage has either an inlet, an outlet, or both.
+A graph is a sequence of stages, consecutive stages will have an outlet and and inlet so that they can join - a graph that has a stage with no outlet followed by a stage that has an inlet is impossible, for example.
+Only the stages at the ends of the graph may have no inlet or outlet, whether these end stages have an inlet or outlet determines the shape of the overall graph.
+The API is responsible for ensuring that as graphs are constructed, only graphs that are logically possible are passed to the `ReactiveStreamsEngine` to construct.

--- a/streams/spec/src/main/asciidoc/examples.asciidoc
+++ b/streams/spec/src/main/asciidoc/examples.asciidoc
@@ -1,0 +1,120 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[reactivestreamsexamples]]
+== Reactive Streams Usage Examples
+
+=== Trivial closed graph
+
+This just shows the fluency of the API.
+It wouldn't make sense to actually do the below in practice, since the JDK8 streams API itself is better for working with in memory streams.
+
+[source, java]
+----
+CompletionStage<Optional<Integer>> result = ReactiveStreams
+    .fromIterable(() -> IntStream.range(1, 1000).boxed().iterator())
+    .filter(i -> (i & 1) == 1)
+    .map(i -> i * 2)
+    .collect(Collectors.reducing((i, j) -> i + j))
+    .run();
+----
+
+=== Building a publisher
+
+This shows building a publisher, transforming a list of objects to CSV file represented as a stream of bytes.
+
+[source, java]
+----
+List<MyDomainObject> domainObjects = ...
+
+Publisher<ByteBuffer> publisher = ReactiveStreams
+    .fromIterable(domainObjects)
+    .map(obj -> String.format("%s,%s\n", obj.getField1(), obj.getField2()))
+    .map(line -> ByteBuffer.wrap(line.getBytes()))
+    .buildRs();
+----
+
+=== Building a subscriber
+
+This shows building a subscriber for a byte stream, such as for the JDK9 HttpClient API.
+It assumes another library has provided a Reactive Streams Processor that parses byte streams into streams of objects.
+
+[source, java]
+----
+Processor<ByteBuffer, MyDomainObject> parser = createParser();
+
+SubscriberWithResult<ByteBuffer, List<MyDomainObject>> sr =
+  ReactiveStreams.<ByteBuffer>builder()
+    .via(parser)
+    .toList()
+    .build();
+
+Subscriber<ByteBuffer> subscriber = sr.getRsSubscriber();
+CompletionStage<List<MyDomainObject>> result = sr.getResult();
+----
+
+=== Building a processor
+
+This shows building a processor, for example, a message library may require processing messages, and then emitting an ACK identifier so that each handled element can be acknowledged as handled.
+
+[source, java]
+----
+Processor<Message<MyDomainObject>, MessageAck> processor =
+    ReactiveStreams.<Message<MyDomainObject>>builder()
+      .map(message -> {
+        handleDomainObject(message.getMessage());
+        return message.getMessageAck();
+      })
+      .buildRs();
+  }
+----
+
+=== Consuming a publisher
+
+A library may provide a Reactive Streams publisher that the application developer needs to consume.
+This shows how that can be done.
+
+[source, java]
+----
+Publisher<ByteBuffer> bytesPublisher = makeRequest();
+
+Processor<ByteBuffer, MyDomainObject> parser = createParser();
+
+CompletionStage<List<MyDomainObject>> result = ReactiveStreams
+    .fromPublisher(bytesPublisher)
+    .via(parser)
+    .toList()
+    .run();
+----
+
+=== Feeding a subscriber
+
+A library may provide a subscriber to feed a connection.
+This shows how that subscriber can be fed.
+
+[source, java]
+----
+List<MyDomainObject> domainObjects = new ArrayList<>();
+
+Subscriber<ByteBuffer> subscriber = createSubscriber();
+
+CompletionStage<Void> completion = ReactiveStreams
+    .fromIterable(domainObjects)
+    .map(obj -> String.format("%s,%s\n", obj.getField1(), obj.getField2()))
+    .map(line -> ByteBuffer.wrap(line.getBytes()))
+    .to(subscriber)
+    .run();
+----

--- a/streams/spec/src/main/asciidoc/license-alv2.asciidoc
+++ b/streams/spec/src/main/asciidoc/license-alv2.asciidoc
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[subs="normal"]
+....
+
+Specification: {doctitle}
+
+Version: {revnumber}
+
+Status: {revremark}
+
+Release: {revdate}
+
+Copyright (c) 2018 Contributors to the Eclipse Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+....

--- a/streams/spec/src/main/asciidoc/microprofile-reactive-streams-spec.asciidoc
+++ b/streams/spec/src/main/asciidoc/microprofile-reactive-streams-spec.asciidoc
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+= MicroProfile Reactive Streams Support Specification
+:authors: James Roper
+:email: james@lightbend.com
+:version-label!:
+:sectanchors:
+:doctype: book
+:license: Apache License v2.0
+:source-highlighter: coderay
+:toc: left
+:toclevels: 4
+:sectnumlevels: 4
+ifdef::backend-pdf[]
+:pagenums:
+endif::[]
+
+
+include::license-alv2.asciidoc[]
+
+== MicroProfile Reactive Streams Support
+
+include::architecture.asciidoc[]
+
+include::examples.asciidoc[]

--- a/streams/tck/pom.xml
+++ b/streams/tck/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<!--
+    Licensed under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+        <artifactId>microprofile-reactive-streams-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+    <artifactId>microprofile-reactive-streams-tck</artifactId>
+    <name>MicroProfile Reactive Streams TCK</name>
+    <description>MicroProfile Reactive Streams :: TCK</description>
+
+    <properties>
+        <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+            <artifactId>microprofile-reactive-streams-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>eclipse-jarsigner</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                        <artifactId>eclipse-jarsigner-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/AbstractStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/AbstractStageVerification.java
@@ -87,7 +87,7 @@ abstract class AbstractStageVerification {
 
     @Override
     public Publisher<T> createFailedPublisher() {
-      return ReactiveStreams.<T>failed(new RuntimeException("failed")).build(engine);
+      return ReactiveStreams.<T>failed(new RuntimeException("failed")).buildRs(engine);
     }
   }
 
@@ -103,7 +103,7 @@ abstract class AbstractStageVerification {
 
     @Override
     public Publisher<T> createFailedPublisher() {
-      return ReactiveStreams.<T>failed(new RuntimeException("failed")).build(engine);
+      return ReactiveStreams.<T>failed(new RuntimeException("failed")).buildRs(engine);
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/AbstractStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/AbstractStageVerification.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.IdentityProcessorVerification;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.SubscriberBlackboxVerification;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+abstract class AbstractStageVerification {
+
+  private final ReactiveStreamsEngine engine;
+  private final TestEnvironment environment;
+  private final ScheduledExecutorService executorService;
+
+  AbstractStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    this.engine = deps.engine();
+    this.environment = deps.testEnvironment();
+    this.executorService = deps.executorService();
+  }
+
+  ReactiveStreamsEngine getEngine() {
+    return engine;
+  }
+
+  ScheduledExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  abstract List<Object> reactiveStreamsTckVerifiers();
+
+  <T> T await(CompletionStage<T> future) {
+    try {
+      return future.toCompletableFuture().get(environment.defaultTimeoutMillis(), TimeUnit.MILLISECONDS);
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    catch (ExecutionException e) {
+      if (e.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) e.getCause();
+      }
+      else {
+        throw new RuntimeException(e.getCause());
+      }
+    }
+    catch (TimeoutException e) {
+      throw new RuntimeException("Future timed out after " + environment.defaultTimeoutMillis() + "ms", e);
+    }
+  }
+
+
+  abstract class StagePublisherVerification<T> extends PublisherVerification<T> {
+
+    StagePublisherVerification() {
+      super(AbstractStageVerification.this.environment);
+    }
+
+    @Override
+    public Publisher<T> createFailedPublisher() {
+      return ReactiveStreams.<T>failed(new RuntimeException("failed")).build(engine);
+    }
+  }
+
+  abstract class StageProcessorVerification<T> extends IdentityProcessorVerification<T> {
+    StageProcessorVerification() {
+      super(AbstractStageVerification.this.environment);
+    }
+
+    @Override
+    public ExecutorService publisherExecutorService() {
+      return executorService;
+    }
+
+    @Override
+    public Publisher<T> createFailedPublisher() {
+      return ReactiveStreams.<T>failed(new RuntimeException("failed")).build(engine);
+    }
+
+    @Override
+    public long maxSupportedSubscribers() {
+      return 1;
+    }
+  }
+
+  abstract class StageSubscriberWhiteboxVerification<T> extends SubscriberWhiteboxVerification<T> {
+    StageSubscriberWhiteboxVerification() {
+      super(AbstractStageVerification.this.environment);
+    }
+  }
+
+  abstract class StageSubscriberBlackboxVerification<T> extends SubscriberBlackboxVerification<T> {
+    StageSubscriberBlackboxVerification() {
+      super(AbstractStageVerification.this.environment);
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CancelStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CancelStageVerification.java
@@ -49,7 +49,7 @@ public class CancelStageVerification extends AbstractStageVerification {
           cancelled.complete(null);
         }
       });
-    }).cancel().build(getEngine());
+    }).cancel().run(getEngine());
     await(cancelled);
     await(result);
   }
@@ -62,7 +62,7 @@ public class CancelStageVerification extends AbstractStageVerification {
   public class SubscriberVerification extends StageSubscriberBlackboxVerification {
     @Override
     public Subscriber createSubscriber() {
-      return ReactiveStreams.builder().cancel().build(getEngine()).getSubscriber();
+      return ReactiveStreams.builder().cancel().build(getEngine()).getRsSubscriber();
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CancelStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CancelStageVerification.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class CancelStageVerification extends AbstractStageVerification {
+  CancelStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void cancelStageShouldCancelTheStage() {
+    CompletableFuture<Void> cancelled = new CompletableFuture<>();
+    CompletionStage<Void> result = ReactiveStreams.fromPublisher(s -> {
+      s.onSubscribe(new Subscription() {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+          cancelled.complete(null);
+        }
+      });
+    }).cancel().build(getEngine());
+    await(cancelled);
+    await(result);
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Arrays.asList(new SubscriberVerification());
+  }
+
+  public class SubscriberVerification extends StageSubscriberBlackboxVerification {
+    @Override
+    public Subscriber createSubscriber() {
+      return ReactiveStreams.builder().cancel().build(getEngine()).getSubscriber();
+    }
+
+    @Override
+    public Object createElement(int element) {
+      return element;
+    }
+
+    @Override
+    public void required_spec201_blackbox_mustSignalDemandViaSubscriptionRequest() throws Throwable {
+      throw new SkipException("Cancel subscriber does not need to signal demand.");
+    }
+
+    @Override
+    public void required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall() throws Throwable {
+      throw new SkipException("Cancel subscriber does not need to signal demand.");
+    }
+
+    @Override
+    public void required_spec210_blackbox_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall() throws Throwable {
+      throw new SkipException("Cancel subscriber does not need to signal demand.");
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CollectStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CollectStageVerification.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Subscriber;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+
+public class CollectStageVerification extends AbstractStageVerification {
+
+  CollectStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void toListStageShouldReturnAList() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3)
+        .toList().build(getEngine())), Arrays.asList(1, 2, 3));
+  }
+
+  @Test
+  public void toListStageShouldReturnEmpty() {
+    assertEquals(await(ReactiveStreams.of()
+        .toList().build(getEngine())), Collections.emptyList());
+  }
+
+  @Test
+  public void finisherFunctionShouldBeInvoked() {
+    assertEquals(await(ReactiveStreams.of("1", "2", "3")
+        .collect(Collectors.joining(", ")).build(getEngine())), "1, 2, 3");
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void toListStageShouldPropagateErrors() {
+    await(ReactiveStreams.failed(new RuntimeException("failed"))
+        .toList().build(getEngine()));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new SubscriberVerification());
+  }
+
+  class SubscriberVerification extends StageSubscriberBlackboxVerification<Integer> {
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+      return ReactiveStreams.<Integer>builder().toList().build(getEngine()).getSubscriber();
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CollectStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/CollectStageVerification.java
@@ -39,25 +39,25 @@ public class CollectStageVerification extends AbstractStageVerification {
   @Test
   public void toListStageShouldReturnAList() {
     assertEquals(await(ReactiveStreams.of(1, 2, 3)
-        .toList().build(getEngine())), Arrays.asList(1, 2, 3));
+        .toList().run(getEngine())), Arrays.asList(1, 2, 3));
   }
 
   @Test
   public void toListStageShouldReturnEmpty() {
     assertEquals(await(ReactiveStreams.of()
-        .toList().build(getEngine())), Collections.emptyList());
+        .toList().run(getEngine())), Collections.emptyList());
   }
 
   @Test
   public void finisherFunctionShouldBeInvoked() {
     assertEquals(await(ReactiveStreams.of("1", "2", "3")
-        .collect(Collectors.joining(", ")).build(getEngine())), "1, 2, 3");
+        .collect(Collectors.joining(", ")).run(getEngine())), "1, 2, 3");
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
   public void toListStageShouldPropagateErrors() {
     await(ReactiveStreams.failed(new RuntimeException("failed"))
-        .toList().build(getEngine()));
+        .toList().run(getEngine()));
   }
 
   @Override
@@ -68,7 +68,7 @@ public class CollectStageVerification extends AbstractStageVerification {
   class SubscriberVerification extends StageSubscriberBlackboxVerification<Integer> {
     @Override
     public Subscriber<Integer> createSubscriber() {
-      return ReactiveStreams.<Integer>builder().toList().build(getEngine()).getSubscriber();
+      return ReactiveStreams.<Integer>builder().toList().build(getEngine()).getRsSubscriber();
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ConcatStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ConcatStageVerification.java
@@ -49,7 +49,7 @@ public class ConcatStageVerification extends AbstractStageVerification {
             ReactiveStreams.of(4, 5, 6)
         )
             .toList()
-            .build(getEngine())
+            .run(getEngine())
     ), Arrays.asList(1, 2, 3, 4, 5, 6));
   }
 
@@ -63,7 +63,7 @@ public class ConcatStageVerification extends AbstractStageVerification {
     )
         .forEach(e -> {
         })
-        .build(getEngine());
+        .run(getEngine());
 
     await(cancelCapture.getCancelled());
     await(completion);
@@ -79,7 +79,7 @@ public class ConcatStageVerification extends AbstractStageVerification {
     )
         .limit(5)
         .toList()
-        .build(getEngine());
+        .run(getEngine());
 
     await(cancelCapture.getCancelled());
     assertEquals(await(result), Arrays.asList(1, 2, 3, 4, 5));
@@ -102,7 +102,7 @@ public class ConcatStageVerification extends AbstractStageVerification {
           ReactiveStreams.fromIterable(
               () -> LongStream.rangeClosed(toEmitFromFirst + 1, elements).boxed().iterator()
           )
-      ).build(getEngine());
+      ).buildRs(getEngine());
     }
   }
 

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ConcatStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ConcatStageVerification.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.testng.Assert.assertEquals;
+
+public class ConcatStageVerification extends AbstractStageVerification {
+
+  ConcatStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void concatStageShouldConcatTwoGraphs() {
+    assertEquals(await(
+        ReactiveStreams.concat(
+            ReactiveStreams.of(1, 2, 3),
+            ReactiveStreams.of(4, 5, 6)
+        )
+            .toList()
+            .build(getEngine())
+    ), Arrays.asList(1, 2, 3, 4, 5, 6));
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void concatStageShouldCancelSecondStageIfFirstFails() {
+    CancelCapturingPublisher<Integer> cancelCapture = new CancelCapturingPublisher<>();
+
+    CompletionStage<Void> completion = ReactiveStreams.concat(
+        ReactiveStreams.failed(new RuntimeException("failed")),
+        ReactiveStreams.fromPublisher(cancelCapture)
+    )
+        .forEach(e -> {
+        })
+        .build(getEngine());
+
+    await(cancelCapture.getCancelled());
+    await(completion);
+  }
+
+  @Test
+  public void concatStageShouldCancelSecondStageIfFirstCancellationOccursDuringFirst() {
+    CancelCapturingPublisher<Integer> cancelCapture = new CancelCapturingPublisher<>();
+
+    CompletionStage<List<Integer>> result = ReactiveStreams.concat(
+        ReactiveStreams.fromIterable(() -> IntStream.range(1, 1000000).boxed().iterator()),
+        ReactiveStreams.fromPublisher(cancelCapture)
+    )
+        .limit(5)
+        .toList()
+        .build(getEngine());
+
+    await(cancelCapture.getCancelled());
+    assertEquals(await(result), Arrays.asList(1, 2, 3, 4, 5));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new PublisherVerification());
+  }
+
+  class PublisherVerification extends StagePublisherVerification<Long> {
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+      long toEmitFromFirst = elements / 2;
+
+      return ReactiveStreams.concat(
+          ReactiveStreams.fromIterable(
+              () -> LongStream.rangeClosed(1, toEmitFromFirst).boxed().iterator()
+          ),
+          ReactiveStreams.fromIterable(
+              () -> LongStream.rangeClosed(toEmitFromFirst + 1, elements).boxed().iterator()
+          )
+      ).build(getEngine());
+    }
+  }
+
+  private static class CancelCapturingPublisher<T> implements Publisher<T> {
+    private final CompletableFuture<T> cancelled = new CompletableFuture<>();
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber) {
+      subscriber.onSubscribe(new Subscription() {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+          cancelled.complete(null);
+        }
+      });
+    }
+
+    public CompletableFuture<T> getCancelled() {
+      return cancelled;
+    }
+  }
+
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ConcatStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ConcatStageVerification.java
@@ -61,8 +61,7 @@ public class ConcatStageVerification extends AbstractStageVerification {
         ReactiveStreams.failed(new RuntimeException("failed")),
         ReactiveStreams.fromPublisher(cancelCapture)
     )
-        .forEach(e -> {
-        })
+        .ignore()
         .run(getEngine());
 
     await(cancelCapture.getCancelled());

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/EmptyProcessorVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/EmptyProcessorVerification.java
@@ -39,7 +39,7 @@ public class EmptyProcessorVerification extends AbstractStageVerification {
   public class ProcessorVerification extends StageProcessorVerification<Integer> {
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
-      return ReactiveStreams.<Integer>builder().build(getEngine());
+      return ReactiveStreams.<Integer>builder().buildRs(getEngine());
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/EmptyProcessorVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/EmptyProcessorVerification.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+
+import java.util.Collections;
+import java.util.List;
+
+public class EmptyProcessorVerification extends AbstractStageVerification {
+
+  public EmptyProcessorVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new ProcessorVerification());
+  }
+
+  public class ProcessorVerification extends StageProcessorVerification<Integer> {
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder().build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FilterStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FilterStageVerification.java
@@ -42,7 +42,7 @@ public class FilterStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6)
         .filter(i -> (i & 1) == 1)
         .toList()
-        .build(getEngine())), Arrays.asList(1, 3, 5));
+        .run(getEngine())), Arrays.asList(1, 3, 5));
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
@@ -52,7 +52,7 @@ public class FilterStageVerification extends AbstractStageVerification {
           throw new RuntimeException("failed");
         })
         .toList()
-        .build(getEngine()));
+        .run(getEngine()));
   }
 
   @Test
@@ -60,7 +60,7 @@ public class FilterStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3, 4)
         .skip(2)
         .toList()
-        .build(getEngine())), Arrays.asList(3, 4));
+        .run(getEngine())), Arrays.asList(3, 4));
   }
 
   @Test
@@ -68,7 +68,7 @@ public class FilterStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3, 4)
         .dropWhile(i -> i < 3)
         .toList()
-        .build(getEngine())), Arrays.asList(3, 4));
+        .run(getEngine())), Arrays.asList(3, 4));
   }
 
   @Test
@@ -78,8 +78,8 @@ public class FilterStageVerification extends AbstractStageVerification {
             .skip(3)
             .toList();
 
-    assertEquals(await(completion.build(getEngine())), Arrays.asList(4, 5, 6));
-    assertEquals(await(completion.build(getEngine())), Arrays.asList(4, 5, 6));
+    assertEquals(await(completion.run(getEngine())), Arrays.asList(4, 5, 6));
+    assertEquals(await(completion.run(getEngine())), Arrays.asList(4, 5, 6));
   }
 
 
@@ -94,13 +94,13 @@ public class FilterStageVerification extends AbstractStageVerification {
 
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
-      return ReactiveStreams.<Integer>builder().filter(i -> true).build(getEngine());
+      return ReactiveStreams.<Integer>builder().filter(i -> true).buildRs(getEngine());
     }
 
     @Override
     public Publisher<Integer> createFailedPublisher() {
       return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
-          .filter(i -> true).build(getEngine());
+          .filter(i -> true).buildRs(getEngine());
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FilterStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FilterStageVerification.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.CompletionBuilder;
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class FilterStageVerification extends AbstractStageVerification {
+
+  FilterStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void filterStageShouldFilterElements() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6)
+        .filter(i -> (i & 1) == 1)
+        .toList()
+        .build(getEngine())), Arrays.asList(1, 3, 5));
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void filterStageShouldPropagateRuntimeExceptions() {
+    await(ReactiveStreams.of("foo")
+        .filter(foo -> {
+          throw new RuntimeException("failed");
+        })
+        .toList()
+        .build(getEngine()));
+  }
+
+  @Test
+  public void filterStageShouldSupportSkip() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3, 4)
+        .skip(2)
+        .toList()
+        .build(getEngine())), Arrays.asList(3, 4));
+  }
+
+  @Test
+  public void filterStageShouldSupportDropWhile() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3, 4)
+        .dropWhile(i -> i < 3)
+        .toList()
+        .build(getEngine())), Arrays.asList(3, 4));
+  }
+
+  @Test
+  public void filterStageShouldInstantiatePredicateOncePerRun() {
+    CompletionBuilder<List<Integer>> completion =
+        ReactiveStreams.of(1, 2, 3, 4, 5, 6)
+            .skip(3)
+            .toList();
+
+    assertEquals(await(completion.build(getEngine())), Arrays.asList(4, 5, 6));
+    assertEquals(await(completion.build(getEngine())), Arrays.asList(4, 5, 6));
+  }
+
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(
+        new ProcessorVerification()
+    );
+  }
+
+  class ProcessorVerification extends StageProcessorVerification<Integer> {
+
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder().filter(i -> true).build(getEngine());
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+      return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
+          .filter(i -> true).build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FindFirstStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FindFirstStageVerification.java
@@ -38,19 +38,19 @@ public class FindFirstStageVerification extends AbstractStageVerification {
   @Test
   public void findFirstStageShouldFindTheFirstElement() {
     assertEquals(await(ReactiveStreams.of(1, 2, 3)
-        .findFirst().build(getEngine())), Optional.of(1));
+        .findFirst().run(getEngine())), Optional.of(1));
   }
 
   @Test
   public void findFirstStageShouldReturnEmpty() {
     assertEquals(await(ReactiveStreams.of()
-        .findFirst().build(getEngine())), Optional.empty());
+        .findFirst().run(getEngine())), Optional.empty());
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
   public void findFirstStageShouldPropagateErrors() {
     await(ReactiveStreams.failed(new RuntimeException("failed"))
-        .findFirst().build(getEngine()));
+        .findFirst().run(getEngine()));
   }
 
   @Override
@@ -61,7 +61,7 @@ public class FindFirstStageVerification extends AbstractStageVerification {
   class SubscriberVerification extends StageSubscriberBlackboxVerification<Integer> {
     @Override
     public Subscriber<Integer> createSubscriber() {
-      return ReactiveStreams.<Integer>builder().findFirst().build(getEngine()).getSubscriber();
+      return ReactiveStreams.<Integer>builder().findFirst().build(getEngine()).getRsSubscriber();
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FindFirstStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FindFirstStageVerification.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Subscriber;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class FindFirstStageVerification extends AbstractStageVerification {
+
+  FindFirstStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void findFirstStageShouldFindTheFirstElement() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3)
+        .findFirst().build(getEngine())), Optional.of(1));
+  }
+
+  @Test
+  public void findFirstStageShouldReturnEmpty() {
+    assertEquals(await(ReactiveStreams.of()
+        .findFirst().build(getEngine())), Optional.empty());
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void findFirstStageShouldPropagateErrors() {
+    await(ReactiveStreams.failed(new RuntimeException("failed"))
+        .findFirst().build(getEngine()));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new SubscriberVerification());
+  }
+
+  class SubscriberVerification extends StageSubscriberBlackboxVerification<Integer> {
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+      return ReactiveStreams.<Integer>builder().findFirst().build(getEngine()).getSubscriber();
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapCompletionStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapCompletionStageVerification.java
@@ -47,7 +47,7 @@ public class FlatMapCompletionStageVerification extends AbstractStageVerificatio
     CompletionStage<List<Integer>> result = ReactiveStreams.of(one, two, three)
         .flatMapCompletionStage(Function.identity())
         .toList()
-        .build(getEngine());
+        .run(getEngine());
 
     Thread.sleep(100);
 
@@ -67,7 +67,7 @@ public class FlatMapCompletionStageVerification extends AbstractStageVerificatio
     CompletionStage<List<Integer>> result = ReactiveStreams.of(one, two, three)
         .flatMapCompletionStage(Function.identity())
         .toList()
-        .build(getEngine());
+        .run(getEngine());
 
     three.complete(3);
     Thread.sleep(100);
@@ -92,7 +92,7 @@ public class FlatMapCompletionStageVerification extends AbstractStageVerificatio
           return i;
         })
         .toList()
-        .build(getEngine());
+        .run(getEngine());
 
     Thread.sleep(100);
     concurrentMaps.decrementAndGet();
@@ -117,7 +117,7 @@ public class FlatMapCompletionStageVerification extends AbstractStageVerificatio
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
       return ReactiveStreams.<Integer>builder()
           .flatMapCompletionStage(CompletableFuture::completedFuture)
-          .build(getEngine());
+          .buildRs(getEngine());
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapCompletionStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapCompletionStageVerification.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+public class FlatMapCompletionStageVerification extends AbstractStageVerification {
+  FlatMapCompletionStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void flatMapCsStageShouldMapFutures() throws Exception {
+    CompletableFuture<Integer> one = new CompletableFuture<>();
+    CompletableFuture<Integer> two = new CompletableFuture<>();
+    CompletableFuture<Integer> three = new CompletableFuture<>();
+
+    CompletionStage<List<Integer>> result = ReactiveStreams.of(one, two, three)
+        .flatMapCompletionStage(Function.identity())
+        .toList()
+        .build(getEngine());
+
+    Thread.sleep(100);
+
+    one.complete(1);
+    two.complete(2);
+    three.complete(3);
+
+    assertEquals(await(result), Arrays.asList(1, 2, 3));
+  }
+
+  @Test
+  public void flatMapCsStageShouldMaintainOrderOfFutures() throws Exception {
+    CompletableFuture<Integer> one = new CompletableFuture<>();
+    CompletableFuture<Integer> two = new CompletableFuture<>();
+    CompletableFuture<Integer> three = new CompletableFuture<>();
+
+    CompletionStage<List<Integer>> result = ReactiveStreams.of(one, two, three)
+        .flatMapCompletionStage(Function.identity())
+        .toList()
+        .build(getEngine());
+
+    three.complete(3);
+    Thread.sleep(100);
+    two.complete(2);
+    Thread.sleep(100);
+    one.complete(1);
+
+    assertEquals(await(result), Arrays.asList(1, 2, 3));
+  }
+
+  @Test
+  public void flatMapCsStageShouldOnlyMapOneElementAtATime() throws Exception {
+    CompletableFuture<Integer> one = new CompletableFuture<>();
+    CompletableFuture<Integer> two = new CompletableFuture<>();
+    CompletableFuture<Integer> three = new CompletableFuture<>();
+
+    AtomicInteger concurrentMaps = new AtomicInteger(0);
+
+    CompletionStage<List<Integer>> result = ReactiveStreams.of(one, two, three)
+        .flatMapCompletionStage(i -> {
+          assertEquals(1, concurrentMaps.incrementAndGet());
+          return i;
+        })
+        .toList()
+        .build(getEngine());
+
+    Thread.sleep(100);
+    concurrentMaps.decrementAndGet();
+    one.complete(1);
+    Thread.sleep(100);
+    concurrentMaps.decrementAndGet();
+    two.complete(2);
+    Thread.sleep(100);
+    concurrentMaps.decrementAndGet();
+    three.complete(3);
+
+    assertEquals(await(result), Arrays.asList(1, 2, 3));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new ProcessorVerification());
+  }
+
+  public class ProcessorVerification extends StageProcessorVerification<Integer> {
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder()
+          .flatMapCompletionStage(CompletableFuture::completedFuture)
+          .build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapIterableStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapIterableStageVerification.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class FlatMapIterableStageVerification extends AbstractStageVerification {
+  FlatMapIterableStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void flatMapIterableStageShouldMapElements() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3)
+        .flatMapIterable(n -> Arrays.asList(n, n, n))
+        .toList()
+        .build(getEngine())), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void flatMapIterableStageShouldPropagateRuntimeExceptions() {
+    await(ReactiveStreams.of("foo")
+        .flatMapIterable(foo -> {
+          throw new RuntimeException("failed");
+        })
+        .toList()
+        .build(getEngine()));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new ProcessorVerification());
+  }
+
+  /**
+   * Verifies the outer processor.
+   */
+  public class ProcessorVerification extends StageProcessorVerification<Integer> {
+
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder().flatMapIterable(Arrays::asList).build(getEngine());
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+      return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
+          .flatMapIterable(Arrays::asList).build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapIterableStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapIterableStageVerification.java
@@ -40,7 +40,7 @@ public class FlatMapIterableStageVerification extends AbstractStageVerification 
     assertEquals(await(ReactiveStreams.of(1, 2, 3)
         .flatMapIterable(n -> Arrays.asList(n, n, n))
         .toList()
-        .build(getEngine())), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
+        .run(getEngine())), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
@@ -50,7 +50,7 @@ public class FlatMapIterableStageVerification extends AbstractStageVerification 
           throw new RuntimeException("failed");
         })
         .toList()
-        .build(getEngine()));
+        .run(getEngine()));
   }
 
   @Override
@@ -65,13 +65,13 @@ public class FlatMapIterableStageVerification extends AbstractStageVerification 
 
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
-      return ReactiveStreams.<Integer>builder().flatMapIterable(Arrays::asList).build(getEngine());
+      return ReactiveStreams.<Integer>builder().flatMapIterable(Arrays::asList).buildRs(getEngine());
     }
 
     @Override
     public Publisher<Integer> createFailedPublisher() {
       return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
-          .flatMapIterable(Arrays::asList).build(getEngine());
+          .flatMapIterable(Arrays::asList).buildRs(getEngine());
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapStageVerification.java
@@ -47,7 +47,7 @@ public class FlatMapStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3)
         .flatMap(n -> ReactiveStreams.of(n, n, n))
         .toList()
-        .build(getEngine())), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
+        .run(getEngine())), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
@@ -57,7 +57,7 @@ public class FlatMapStageVerification extends AbstractStageVerification {
           throw new RuntimeException("failed");
         })
         .toList()
-        .build(getEngine()));
+        .run(getEngine()));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class FlatMapStageVerification extends AbstractStageVerification {
     CompletionStage<List<Integer>> result = ReactiveStreams.of(1, 2, 3, 4, 5)
         .flatMap(id -> ReactiveStreams.fromPublisher(new ScheduledPublisher(id)))
         .toList()
-        .build(getEngine());
+        .run(getEngine());
 
     assertEquals(result.toCompletableFuture().get(2, TimeUnit.SECONDS),
         Arrays.asList(1, 2, 3, 4, 5));
@@ -122,13 +122,13 @@ public class FlatMapStageVerification extends AbstractStageVerification {
 
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
-      return ReactiveStreams.<Integer>builder().flatMap(ReactiveStreams::of).build(getEngine());
+      return ReactiveStreams.<Integer>builder().flatMap(ReactiveStreams::of).buildRs(getEngine());
     }
 
     @Override
     public Publisher<Integer> createFailedPublisher() {
       return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
-          .flatMap(ReactiveStreams::of).build(getEngine());
+          .flatMap(ReactiveStreams::of).buildRs(getEngine());
     }
 
     @Override
@@ -180,7 +180,7 @@ public class FlatMapStageVerification extends AbstractStageVerification {
               probe.registerOnComplete();
             }
           })
-          .build(getEngine());
+          .run(getEngine());
 
       return (Subscriber) await(subscriber);
     }

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FlatMapStageVerification.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+public class FlatMapStageVerification extends AbstractStageVerification {
+  FlatMapStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void flatMapStageShouldMapElements() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3)
+        .flatMap(n -> ReactiveStreams.of(n, n, n))
+        .toList()
+        .build(getEngine())), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void flatMapStageShouldPropagateRuntimeExceptions() {
+    await(ReactiveStreams.of("foo")
+        .flatMap(foo -> {
+          throw new RuntimeException("failed");
+        })
+        .toList()
+        .build(getEngine()));
+  }
+
+  @Test
+  public void flatMapStageShouldOnlySubscribeToOnePublisherAtATime() throws Exception {
+    AtomicInteger activePublishers = new AtomicInteger();
+
+    // A publisher that publishes one element 100ms after being requested,
+    // and then completes 100ms later. It also uses activePublishers to ensure
+    // that it is the only publisher that is subscribed to at any one time.
+    class ScheduledPublisher implements Publisher<Integer> {
+      private final int id;
+
+      private ScheduledPublisher(int id) {
+        this.id = id;
+      }
+
+      private AtomicBoolean published = new AtomicBoolean(false);
+
+      @Override
+      public void subscribe(Subscriber<? super Integer> subscriber) {
+        assertEquals(activePublishers.incrementAndGet(), 1);
+        subscriber.onSubscribe(new Subscription() {
+          @Override
+          public void request(long n) {
+            if (published.compareAndSet(false, true)) {
+              getExecutorService().schedule(() -> {
+                subscriber.onNext(id);
+                getExecutorService().schedule(() -> {
+                  activePublishers.decrementAndGet();
+                  subscriber.onComplete();
+                }, 100, TimeUnit.MILLISECONDS);
+              }, 100, TimeUnit.MILLISECONDS);
+            }
+          }
+
+          @Override
+          public void cancel() {
+          }
+        });
+      }
+    }
+
+    CompletionStage<List<Integer>> result = ReactiveStreams.of(1, 2, 3, 4, 5)
+        .flatMap(id -> ReactiveStreams.fromPublisher(new ScheduledPublisher(id)))
+        .toList()
+        .build(getEngine());
+
+    assertEquals(result.toCompletableFuture().get(2, TimeUnit.SECONDS),
+        Arrays.asList(1, 2, 3, 4, 5));
+  }
+
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Arrays.asList(new OuterProcessorVerification(), new InnerSubscriberVerification());
+  }
+
+  /**
+   * Verifies the outer processor.
+   */
+  public class OuterProcessorVerification extends StageProcessorVerification<Integer> {
+
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder().flatMap(ReactiveStreams::of).build(getEngine());
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+      return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
+          .flatMap(ReactiveStreams::of).build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+
+  /**
+   * Verifies the inner subscriber passed to publishers produced by the mapper function.
+   */
+  public class InnerSubscriberVerification extends StageSubscriberWhiteboxVerification<Integer> {
+
+    @Override
+    public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+      CompletableFuture<Subscriber<? super Integer>> subscriber = new CompletableFuture<>();
+      ReactiveStreams.of(ReactiveStreams.<Integer>fromPublisher(subscriber::complete))
+          .flatMap(Function.identity())
+          .to(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+              // We need to initially request an element to ensure that we get the publisher.
+              subscription.request(1);
+              probe.registerOnSubscribe(new SubscriberPuppet() {
+                @Override
+                public void triggerRequest(long elements) {
+                  subscription.request(elements);
+                }
+
+                @Override
+                public void signalCancel() {
+                  subscription.cancel();
+                }
+              });
+            }
+
+            @Override
+            public void onNext(Integer item) {
+              probe.registerOnNext(item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+              probe.registerOnError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+              probe.registerOnComplete();
+            }
+          })
+          .build(getEngine());
+
+      return (Subscriber) await(subscriber);
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/MapStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/MapStageVerification.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+public class MapStageVerification extends AbstractStageVerification {
+
+  MapStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void mapStageShouldMapElements() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3)
+        .map(Object::toString)
+        .toList()
+        .build(getEngine())), Arrays.asList("1", "2", "3"));
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void mapStageShouldPropagateRuntimeExceptions() {
+    await(ReactiveStreams.of("foo")
+        .map(foo -> {
+          throw new RuntimeException("failed");
+        })
+        .toList()
+        .build(getEngine()));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(
+        new ProcessorVerification()
+    );
+  }
+
+  public class ProcessorVerification extends StageProcessorVerification<Integer> {
+
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder().map(Function.identity()).build(getEngine());
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+      return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
+          .map(Function.identity()).build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/MapStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/MapStageVerification.java
@@ -42,7 +42,7 @@ public class MapStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3)
         .map(Object::toString)
         .toList()
-        .build(getEngine())), Arrays.asList("1", "2", "3"));
+        .run(getEngine())), Arrays.asList("1", "2", "3"));
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
@@ -52,7 +52,7 @@ public class MapStageVerification extends AbstractStageVerification {
           throw new RuntimeException("failed");
         })
         .toList()
-        .build(getEngine()));
+        .run(getEngine()));
   }
 
   @Override
@@ -66,13 +66,13 @@ public class MapStageVerification extends AbstractStageVerification {
 
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
-      return ReactiveStreams.<Integer>builder().map(Function.identity()).build(getEngine());
+      return ReactiveStreams.<Integer>builder().map(Function.identity()).buildRs(getEngine());
     }
 
     @Override
     public Publisher<Integer> createFailedPublisher() {
       return ReactiveStreams.<Integer>failed(new RuntimeException("failed"))
-          .map(Function.identity()).build(getEngine());
+          .map(Function.identity()).buildRs(getEngine());
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/OfStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/OfStageVerification.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.testng.Assert.assertEquals;
+
+public class OfStageVerification extends AbstractStageVerification {
+
+  OfStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void iterableStageShouldEmitManyElements() {
+    assertEquals(await(
+        ReactiveStreams.of("a", "b", "c")
+            .toList()
+            .build(getEngine())
+    ), Arrays.asList("a", "b", "c"));
+  }
+
+  @Test
+  public void emptyIterableStageShouldEmitNoElements() {
+    assertEquals(await(
+        ReactiveStreams.empty()
+            .toList()
+            .build(getEngine())
+    ), Collections.emptyList());
+  }
+
+  @Test
+  public void singleIterableStageShouldEmitOneElement() {
+    assertEquals(await(
+        ReactiveStreams.of("a")
+            .toList()
+            .build(getEngine())
+    ), Collections.singletonList("a"));
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new PublisherVerification());
+  }
+
+  public class PublisherVerification extends StagePublisherVerification<Long> {
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+      return ReactiveStreams.fromIterable(
+          () -> LongStream.rangeClosed(1, elements).boxed().iterator()
+      ).build(getEngine());
+    }
+  }
+
+
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/OfStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/OfStageVerification.java
@@ -41,7 +41,7 @@ public class OfStageVerification extends AbstractStageVerification {
     assertEquals(await(
         ReactiveStreams.of("a", "b", "c")
             .toList()
-            .build(getEngine())
+            .run(getEngine())
     ), Arrays.asList("a", "b", "c"));
   }
 
@@ -50,7 +50,7 @@ public class OfStageVerification extends AbstractStageVerification {
     assertEquals(await(
         ReactiveStreams.empty()
             .toList()
-            .build(getEngine())
+            .run(getEngine())
     ), Collections.emptyList());
   }
 
@@ -59,7 +59,7 @@ public class OfStageVerification extends AbstractStageVerification {
     assertEquals(await(
         ReactiveStreams.of("a")
             .toList()
-            .build(getEngine())
+            .run(getEngine())
     ), Collections.singletonList("a"));
   }
 
@@ -73,7 +73,7 @@ public class OfStageVerification extends AbstractStageVerification {
     public Publisher<Long> createPublisher(long elements) {
       return ReactiveStreams.fromIterable(
           () -> LongStream.rangeClosed(1, elements).boxed().iterator()
-      ).build(getEngine());
+      ).buildRs(getEngine());
     }
   }
 

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ReactiveStreamsTck.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ReactiveStreamsTck.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.Factory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+/**
+ * The Reactive Streams TCK.
+ * <p>
+ * A concrete class that extends this class is all that is needed to verify a {@link ReactiveStreamsEngine} against
+ * this TCK.
+ * <p>
+ * It produces a number of TestNG test classes via the TestNG {@link Factory} annotated {@link #allTests()} method.
+ *
+ * @param <E> The type of the Reactive Streams engine.
+ */
+public abstract class ReactiveStreamsTck<E extends ReactiveStreamsEngine> {
+
+  private final TestEnvironment testEnvironment;
+
+  public ReactiveStreamsTck(TestEnvironment testEnvironment) {
+    this.testEnvironment = testEnvironment;
+  }
+
+  /**
+   * Override to provide the reactive streams engine.
+   */
+  protected abstract E createEngine();
+
+  /**
+   * Override to implement custom shutdown logic for the Reactive Streams engine.
+   */
+  protected void shutdownEngine(E engine) {
+    // By default, do nothing.
+  }
+
+  /**
+   * Override this to disable/enable tests, useful for debugging one test at a time.
+   */
+  protected boolean isEnabled(Object test) {
+    return true;
+  }
+
+  private E engine;
+  private ScheduledExecutorService executorService;
+
+  @AfterSuite(alwaysRun = true)
+  public void shutdownEngine() {
+    if (engine != null) {
+      shutdownEngine(engine);
+    }
+  }
+
+  @Factory
+  public Object[] allTests() {
+    engine = createEngine();
+    executorService = Executors.newScheduledThreadPool(4);
+
+    List<Function<VerificationDeps, AbstractStageVerification>> stageVerifications = Arrays.asList(
+        OfStageVerification::new,
+        MapStageVerification::new,
+        FlatMapStageVerification::new,
+        FilterStageVerification::new,
+        FindFirstStageVerification::new,
+        CollectStageVerification::new,
+        TakeWhileStageVerification::new,
+        FlatMapCompletionStageVerification::new,
+        FlatMapIterableStageVerification::new,
+        ConcatStageVerification::new,
+        EmptyProcessorVerification::new,
+        CancelStageVerification::new,
+        SubscriberStageVerification::new
+    );
+
+    List<Object> allTests = new ArrayList<>();
+    VerificationDeps deps = new VerificationDeps();
+    for (Function<VerificationDeps, AbstractStageVerification> creator : stageVerifications) {
+      AbstractStageVerification stageVerification = creator.apply(deps);
+      allTests.add(stageVerification);
+      allTests.addAll(stageVerification.reactiveStreamsTckVerifiers());
+    }
+
+    return allTests.stream().filter(this::isEnabled).toArray();
+  }
+
+  class VerificationDeps {
+    ReactiveStreamsEngine engine() {
+      return engine;
+    }
+
+    TestEnvironment testEnvironment() {
+      return testEnvironment;
+    }
+
+    ScheduledExecutorService executorService() {
+      return executorService;
+    }
+  }
+
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/SubscriberStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/SubscriberStageVerification.java
@@ -36,16 +36,16 @@ public class SubscriberStageVerification extends AbstractStageVerification {
   @Test
   public void subscriberStageShouldRedeemCompletionStageWhenCompleted() {
     CompletionStage<Void> result = ReactiveStreams.of().to(
-        ReactiveStreams.builder().ignore().build(getEngine()).getSubscriber()
-    ).build(getEngine());
+        ReactiveStreams.builder().ignore().build(getEngine()).getRsSubscriber()
+    ).run(getEngine());
     await(result);
   }
 
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
   public void subscriberStageShouldRedeemCompletionStageWhenFailed() {
     CompletionStage<Void> result = ReactiveStreams.failed(new RuntimeException("failed")).to(
-        ReactiveStreams.builder().ignore().build(getEngine()).getSubscriber()
-    ).build(getEngine());
+        ReactiveStreams.builder().ignore().build(getEngine()).getRsSubscriber()
+    ).run(getEngine());
     await(result);
   }
 
@@ -62,8 +62,8 @@ public class SubscriberStageVerification extends AbstractStageVerification {
         }
       });
     }).to(
-        ReactiveStreams.builder().cancel().build(getEngine()).getSubscriber()
-    ).build(getEngine());
+        ReactiveStreams.builder().cancel().build(getEngine()).getRsSubscriber()
+    ).run(getEngine());
     await(result);
   }
 

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/SubscriberStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/SubscriberStageVerification.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionStage;
+
+public class SubscriberStageVerification extends AbstractStageVerification {
+  SubscriberStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void subscriberStageShouldRedeemCompletionStageWhenCompleted() {
+    CompletionStage<Void> result = ReactiveStreams.of().to(
+        ReactiveStreams.builder().ignore().build(getEngine()).getSubscriber()
+    ).build(getEngine());
+    await(result);
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+  public void subscriberStageShouldRedeemCompletionStageWhenFailed() {
+    CompletionStage<Void> result = ReactiveStreams.failed(new RuntimeException("failed")).to(
+        ReactiveStreams.builder().ignore().build(getEngine()).getSubscriber()
+    ).build(getEngine());
+    await(result);
+  }
+
+  @Test(expectedExceptions = CancellationException.class)
+  public void subscriberStageShouldRedeemCompletionStageWithCancellationExceptionWhenCancelled() {
+    CompletionStage<Void> result = ReactiveStreams.fromPublisher(subscriber -> {
+      subscriber.onSubscribe(new Subscription() {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+      });
+    }).to(
+        ReactiveStreams.builder().cancel().build(getEngine()).getSubscriber()
+    ).build(getEngine());
+    await(result);
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.emptyList();
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/TakeWhileStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/TakeWhileStageVerification.java
@@ -42,7 +42,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6, 1, 2)
         .takeWhile(i -> i < 5)
         .toList()
-        .build(getEngine())), Arrays.asList(1, 2, 3, 4));
+        .run(getEngine())), Arrays.asList(1, 2, 3, 4));
   }
 
   @Test
@@ -50,7 +50,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6)
         .takeWhile(i -> false)
         .toList()
-        .build(getEngine())), Collections.emptyList());
+        .run(getEngine())), Collections.emptyList());
   }
 
   @Test
@@ -58,7 +58,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
     assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6)
         .limit(3)
         .toList()
-        .build(getEngine())), Arrays.asList(1, 2, 3));
+        .run(getEngine())), Arrays.asList(1, 2, 3));
   }
 
   @Test
@@ -78,7 +78,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
         })
     ).limit(1)
         .toList()
-        .build(getEngine());
+        .run(getEngine());
     await(cancelled);
   }
 
@@ -96,7 +96,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
             })
             .limit(3)
             .toList()
-            .build(getEngine())
+            .run(getEngine())
     ), Arrays.asList(1, 2, 3));
   }
 
@@ -106,7 +106,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
         ReactiveStreams.of(1, 2, 3, 4)
             .limit(0)
             .toList()
-            .build(getEngine())
+            .run(getEngine())
     ), Collections.emptyList());
   }
 
@@ -120,7 +120,7 @@ public class TakeWhileStageVerification extends AbstractStageVerification {
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
       return ReactiveStreams.<Integer>builder()
           .takeWhile(t -> true)
-          .build(getEngine());
+          .buildRs(getEngine());
     }
 
     @Override

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/TakeWhileStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/TakeWhileStageVerification.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.testng.Assert.assertEquals;
+
+public class TakeWhileStageVerification extends AbstractStageVerification {
+
+  TakeWhileStageVerification(ReactiveStreamsTck.VerificationDeps deps) {
+    super(deps);
+  }
+
+  @Test
+  public void takeWhileStageShouldTakeWhileConditionIsTrue() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6, 1, 2)
+        .takeWhile(i -> i < 5)
+        .toList()
+        .build(getEngine())), Arrays.asList(1, 2, 3, 4));
+  }
+
+  @Test
+  public void takeWhileStageShouldEmitEmpty() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6)
+        .takeWhile(i -> false)
+        .toList()
+        .build(getEngine())), Collections.emptyList());
+  }
+
+  @Test
+  public void takeWhileStageShouldSupportLimit() {
+    assertEquals(await(ReactiveStreams.of(1, 2, 3, 4, 5, 6)
+        .limit(3)
+        .toList()
+        .build(getEngine())), Arrays.asList(1, 2, 3));
+  }
+
+  @Test
+  public void takeWhileShouldCancelUpStreamWhenDone() {
+    CompletableFuture<Void> cancelled = new CompletableFuture<>();
+    ReactiveStreams.<Integer>fromPublisher(subscriber ->
+        subscriber.onSubscribe(new Subscription() {
+          @Override
+          public void request(long n) {
+            subscriber.onNext(1);
+          }
+
+          @Override
+          public void cancel() {
+            cancelled.complete(null);
+          }
+        })
+    ).limit(1)
+        .toList()
+        .build(getEngine());
+    await(cancelled);
+  }
+
+  @Test
+  public void takeWhileShouldIgnoreSubsequentErrorsWhenDone() {
+    assertEquals(await(
+        ReactiveStreams.of(1, 2, 3, 4)
+            .flatMap(i -> {
+              if (i == 4) {
+                return ReactiveStreams.failed(new RuntimeException("failed"));
+              }
+              else {
+                return ReactiveStreams.of(i);
+              }
+            })
+            .limit(3)
+            .toList()
+            .build(getEngine())
+    ), Arrays.asList(1, 2, 3));
+  }
+
+  @Test
+  public void takeWhileShouldSupportLimitingToZero() {
+    assertEquals(await(
+        ReactiveStreams.of(1, 2, 3, 4)
+            .limit(0)
+            .toList()
+            .build(getEngine())
+    ), Collections.emptyList());
+  }
+
+  @Override
+  List<Object> reactiveStreamsTckVerifiers() {
+    return Collections.singletonList(new ProcessorVerification());
+  }
+
+  public class ProcessorVerification extends StageProcessorVerification<Integer> {
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+      return ReactiveStreams.<Integer>builder()
+          .takeWhile(t -> true)
+          .build(getEngine());
+    }
+
+    @Override
+    public Integer createElement(int element) {
+      return element;
+    }
+  }
+}


### PR DESCRIPTION
This is an import of the specification for MicroProfile Reactive Streams.

This specification started off as a proposal for a JDK Reactive Streams manipulation API. See the Rationale section in the architecture.asciidoc file in this Pull Request to see why this specification is needed. The specification is by no means complete, but it is a necessary first step before any other APIs that are based around Reactive Streams in MicroProfile can be added, once again, the Rationale section of architecture.asciidoc explains why, so I won't repeat it here.

To make clear, this is not the MicroProfile messaging spec that has been worked on in the microprofile-sandbox project - that specification will come as a PR for an additional subproject in this repository once this PR is merged.