### PR TITLE
Remove the abstract ReactiveStreamsBuilder superclass

### DIFF
--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionBuilder.java
@@ -20,7 +20,6 @@
 package org.eclipse.microprofile.reactive.streams;
 
 import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
-import org.eclipse.microprofile.reactive.streams.spi.Stage;
 
 import java.util.concurrent.CompletionStage;
 
@@ -34,11 +33,14 @@ import java.util.concurrent.CompletionStage;
  * @param <T> The result of the stream.
  * @see ReactiveStreams
  */
-public final class CompletionBuilder<T> extends ReactiveStreamsBuilder {
+public final class CompletionBuilder<T> {
 
-  CompletionBuilder(Stage stage, ReactiveStreamsBuilder previous) {
-    super(stage, previous);
+  private final ReactiveStreamsGraphBuilder graphBuilder;
+
+  CompletionBuilder(ReactiveStreamsGraphBuilder graphBuilder) {
+    this.graphBuilder = graphBuilder;
   }
+
 
   /**
    * Run this stream, using the first {@link ReactiveStreamsEngine} found by the {@link java.util.ServiceLoader}.
@@ -46,7 +48,7 @@ public final class CompletionBuilder<T> extends ReactiveStreamsBuilder {
    * @return A completion stage that will be redeemed with the result of the stream, or an error if the stream fails.
    */
   public CompletionStage<T> run() {
-    return run(defaultEngine());
+    return run(ReactiveStreamsGraphBuilder.defaultEngine());
   }
 
   /**
@@ -56,6 +58,6 @@ public final class CompletionBuilder<T> extends ReactiveStreamsBuilder {
    * @return A completion stage that will be redeemed with the result of the stream, or an error if the stream fails.
    */
   public CompletionStage<T> run(ReactiveStreamsEngine engine) {
-    return engine.buildCompletion(toGraph(false, false));
+    return engine.buildCompletion(graphBuilder.build(false, false));
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/InternalStages.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/InternalStages.java
@@ -34,7 +34,7 @@ class InternalStages {
    * An identity stage - this stage simply passes is input to its output unchanged. It's used to represent processor
    * builders that have had no stages defined.
    * <p>
-   * It gets ignored by the {@link ReactiveStreamsBuilder} when encountered.
+   * It gets ignored by the {@link ReactiveStreamsGraphBuilder} when encountered.
    */
   static final class Identity implements InternalStage {
     private Identity() {
@@ -47,17 +47,17 @@ class InternalStages {
    * A nested stage. This is used to avoid having to rebuild the entire graph (which is represented as an immutable
    * cons) whenever two graphs are joined, or a stage is prepended into the graph.
    * <p>
-   * It gets flattened out by the {@link ReactiveStreamsBuilder} when building the graph.
+   * It gets flattened out by the {@link ReactiveStreamsGraphBuilder} when building the graph.
    */
   static final class Nested implements InternalStage {
-    private final ReactiveStreamsBuilder stage;
+    private final ReactiveStreamsGraphBuilder graphBuilder;
 
-    Nested(ReactiveStreamsBuilder stage) {
-      this.stage = stage;
+    Nested(ReactiveStreamsGraphBuilder graphBuilder) {
+      this.graphBuilder = graphBuilder;
     }
 
-    ReactiveStreamsBuilder getBuilder() {
-      return stage;
+    ReactiveStreamsGraphBuilder getBuilder() {
+      return graphBuilder;
     }
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
@@ -48,7 +48,7 @@ public class ReactiveStreams {
    * @return A publisher builder that wraps the given publisher.
    */
   public static <T> PublisherBuilder<T> fromPublisher(Publisher<? extends T> publisher) {
-    return new PublisherBuilder<>(new Stage.PublisherStage(publisher), null);
+    return new PublisherBuilder<>(new Stage.PublisherStage(publisher));
   }
 
   /**
@@ -59,7 +59,7 @@ public class ReactiveStreams {
    * @return A publisher builder that will emit the element.
    */
   public static <T> PublisherBuilder<T> of(T t) {
-    return new PublisherBuilder<>(new Stage.Of(Arrays.asList(t)), null);
+    return new PublisherBuilder<>(new Stage.Of(Arrays.asList(t)));
   }
 
   /**
@@ -80,7 +80,7 @@ public class ReactiveStreams {
    * @return A publisher builder that will just emit a completion signal.
    */
   public static <T> PublisherBuilder<T> empty() {
-    return new PublisherBuilder<>(Stage.Of.EMPTY, null);
+    return new PublisherBuilder<>(Stage.Of.EMPTY);
   }
 
   /**
@@ -103,7 +103,7 @@ public class ReactiveStreams {
    * @return A publisher builder that emits the elements of the iterable.
    */
   public static <T> PublisherBuilder<T> fromIterable(Iterable<? extends T> ts) {
-    return new PublisherBuilder<>(new Stage.Of(ts), null);
+    return new PublisherBuilder<>(new Stage.Of(ts));
   }
 
   /**
@@ -116,7 +116,7 @@ public class ReactiveStreams {
    * @return A publisher builder that completes the stream with an error.
    */
   public static <T> PublisherBuilder<T> failed(Throwable t) {
-    return new PublisherBuilder<>(new Stage.Failed(t), null);
+    return new PublisherBuilder<>(new Stage.Failed(t));
   }
 
   /**
@@ -126,7 +126,7 @@ public class ReactiveStreams {
    * @return The identity processor builder.
    */
   public static <T> ProcessorBuilder<T, T> builder() {
-    return new ProcessorBuilder<>(InternalStages.Identity.INSTANCE, null);
+    return new ProcessorBuilder<>(InternalStages.Identity.INSTANCE);
   }
 
   /**
@@ -138,7 +138,7 @@ public class ReactiveStreams {
    * @return A processor builder that wraps the processor.
    */
   public static <T, R> ProcessorBuilder<T, R> fromProcessor(Processor<? super T, ? extends R> processor) {
-    return new ProcessorBuilder<>(new Stage.ProcessorStage(processor), null);
+    return new ProcessorBuilder<>(new Stage.ProcessorStage(processor));
   }
 
   /**
@@ -149,7 +149,7 @@ public class ReactiveStreams {
    * @return A subscriber builder that wraps the subscriber.
    */
   public static <T> SubscriberBuilder<T, Void> fromSubscriber(Subscriber<? extends T> subscriber) {
-    return new SubscriberBuilder<>(new Stage.SubscriberStage(subscriber), null);
+    return new SubscriberBuilder<>(new Stage.SubscriberStage(subscriber));
   }
 
   /**
@@ -195,6 +195,6 @@ public class ReactiveStreams {
    */
   public static <T> PublisherBuilder<T> concat(PublisherBuilder<? extends T> a,
       PublisherBuilder<? extends T> b) {
-    return new PublisherBuilder<>(new Stage.Concat(a.toGraph(), b.toGraph()), null);
+    return new PublisherBuilder<>(new Stage.Concat(a.toGraph(), b.toGraph()));
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
@@ -34,10 +34,16 @@ import org.eclipse.microprofile.reactive.streams.spi.Stage;
  * @param <R> The type of the result that this subscriber emits.
  * @see ReactiveStreams
  */
-public final class SubscriberBuilder<T, R> extends ReactiveStreamsBuilder {
+public final class SubscriberBuilder<T, R> {
 
-  SubscriberBuilder(Stage stage, ReactiveStreamsBuilder previous) {
-    super(stage, previous);
+  private final ReactiveStreamsGraphBuilder graphBuilder;
+
+  SubscriberBuilder(ReactiveStreamsGraphBuilder graphBuilder) {
+    this.graphBuilder = graphBuilder;
+  }
+
+  SubscriberBuilder(Stage stage) {
+    this.graphBuilder = new ReactiveStreamsGraphBuilder(stage);
   }
 
   /**
@@ -46,7 +52,7 @@ public final class SubscriberBuilder<T, R> extends ReactiveStreamsBuilder {
    * @return A {@link SubscriberWithResult} that will run this stream.
    */
   public SubscriberWithResult<T, R> build() {
-    return build(defaultEngine());
+    return build(ReactiveStreamsGraphBuilder.defaultEngine());
   }
 
   /**
@@ -56,6 +62,10 @@ public final class SubscriberBuilder<T, R> extends ReactiveStreamsBuilder {
    * @return A {@link SubscriberWithResult} that will run this stream.
    */
   public SubscriberWithResult<T, R> build(ReactiveStreamsEngine engine) {
-    return engine.buildSubscriber(toGraph(true, false));
+    return engine.buildSubscriber(graphBuilder.build(true, false));
+  }
+
+  ReactiveStreamsGraphBuilder getGraphBuilder() {
+    return graphBuilder;
   }
 }


### PR DESCRIPTION
This superclass didn't actually provide any public functionality, it was just an implementation convenience, and therefore introduced confusion in the API. Instead, a private ReactiveStreamsGraphBuilder class is introduced that implements its functionality, and each public API build has one of these, and works with these.

The removal of this was discussed in the MicroProfile hangout, and also in issue #6.