### PR TITLE
Fix typos in the peek stage javadoc and signature

### DIFF
--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
@@ -73,7 +73,7 @@ public final class ProcessorBuilder<T, R> {
    * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between,
    * the given function is called for each element.
    */
-  public ProcessorBuilder<T, T> peek(Consumer<? super T> consumer) {
+  public ProcessorBuilder<T, R> peek(Consumer<? super R> consumer) {
     return addStage(new Stage.Peek(consumer));
   }
 

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
@@ -66,14 +66,14 @@ public final class ProcessorBuilder<T, R> {
   }
 
   /**
-   * Returns a stream containing all the elements from this stream, 
-   * additionaly perfoming the provided action on each element.
+   * Returns a stream containing all the elements from this stream, additionally performing the provided action on each
+   * element.
    *
    * @param consumer The function called for every element.
-   * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between, the given function 
-   * is called for each element.
+   * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between,
+   * the given function is called for each element.
    */
-  public ProcessorBuilder<T, R> peek(Consumer<? super R> consumer) {
+  public ProcessorBuilder<T, T> peek(Consumer<? super T> consumer) {
     return addStage(new Stage.Peek(consumer));
   }
 

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
@@ -67,12 +67,12 @@ public final class PublisherBuilder<T> {
   }
 
   /**
-   * Returns a stream containing all the elements from this stream, 
-   * additionaly perfoming the provided action on each element.
+   * Returns a stream containing all the elements from this stream, additionally performing the provided action on each
+   * element.
    *
    * @param consumer The function called for every element.
-   * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between, the given function 
-   * is called for each element.
+   * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between,
+   * the given function is called for each element.
    */
   public PublisherBuilder<T> peek(Consumer<? super T> consumer) {
     return addStage(new Stage.Peek(consumer));


### PR DESCRIPTION
Fix typos in the javadoc of the `peek` stage.