### PR TITLE
Rename CompletionBuilder to CompletionRunner

### DIFF
--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionRunner.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionRunner.java
@@ -33,11 +33,11 @@ import java.util.concurrent.CompletionStage;
  * @param <T> The result of the stream.
  * @see ReactiveStreams
  */
-public final class CompletionBuilder<T> {
+public final class CompletionRunner<T> {
 
   private final ReactiveStreamsGraphBuilder graphBuilder;
 
-  CompletionBuilder(ReactiveStreamsGraphBuilder graphBuilder) {
+  CompletionRunner(ReactiveStreamsGraphBuilder graphBuilder) {
     this.graphBuilder = graphBuilder;
   }
 

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
@@ -67,11 +67,11 @@ public final class PublisherBuilder<T> {
   }
 
   /**
-   * Returns a stream containing all the elements from this stream, 
+   * Returns a stream containing all the elements from this stream,
    * additionaly perfoming the provided action on each element.
    *
    * @param consumer The function called for every element.
-   * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between, the given function 
+   * @return A new processor builder that consumes elements of type <code>T</code> and emits the same elements. In between, the given function
    * is called for each element.
    */
   public PublisherBuilder<T> peek(Consumer<? super T> consumer) {
@@ -236,7 +236,7 @@ public final class PublisherBuilder<T> {
    * @param action The action.
    * @return A new completion builder.
    */
-  public CompletionBuilder<Void> forEach(Consumer<? super T> action) {
+  public CompletionRunner<Void> forEach(Consumer<? super T> action) {
     return collect(Collector.<T, Void, Void>of(
         () -> null,
         (n, t) -> action.accept(t),
@@ -254,7 +254,7 @@ public final class PublisherBuilder<T> {
    *
    * @return A new completion builder.
    */
-  public CompletionBuilder<Void> ignore() {
+  public CompletionRunner<Void> ignore() {
     return forEach(r -> {
     });
   }
@@ -266,7 +266,7 @@ public final class PublisherBuilder<T> {
    *
    * @return A new completion builder.
    */
-  public CompletionBuilder<Void> cancel() {
+  public CompletionRunner<Void> cancel() {
     return addTerminalStage(Stage.Cancel.INSTANCE);
   }
 
@@ -280,7 +280,7 @@ public final class PublisherBuilder<T> {
    * @param accumulator The accumulator function.
    * @return A new completion builder.
    */
-  public CompletionBuilder<T> reduce(T identity, BinaryOperator<T> accumulator) {
+  public CompletionRunner<T> reduce(T identity, BinaryOperator<T> accumulator) {
     return addTerminalStage(new Stage.Collect(Reductions.reduce(identity, accumulator)));
   }
 
@@ -293,7 +293,7 @@ public final class PublisherBuilder<T> {
    * @param accumulator The accumulator function.
    * @return A new completion builder.
    */
-  public CompletionBuilder<Optional<T>> reduce(BinaryOperator<T> accumulator) {
+  public CompletionRunner<Optional<T>> reduce(BinaryOperator<T> accumulator) {
     return addTerminalStage(new Stage.Collect(Reductions.reduce(accumulator)));
   }
 
@@ -308,9 +308,9 @@ public final class PublisherBuilder<T> {
    * @param combiner    The combiner function.
    * @return A new completion builder.
    */
-  public <S> CompletionBuilder<S> reduce(S identity,
-      BiFunction<S, ? super T, S> accumulator,
-      BinaryOperator<S> combiner) {
+  public <S> CompletionRunner<S> reduce(S identity,
+                                        BiFunction<S, ? super T, S> accumulator,
+                                        BinaryOperator<S> combiner) {
 
     return addTerminalStage(new Stage.Collect(Reductions.reduce(identity, accumulator, combiner)));
   }
@@ -321,9 +321,9 @@ public final class PublisherBuilder<T> {
    * <p>
    * If the stream is completed before a single element is emitted, then {@link Optional#empty()} will be emitted.
    *
-   * @return A {@link CompletionBuilder} that emits the element when found.
+   * @return A {@link CompletionRunner} that emits the element when found.
    */
-  public CompletionBuilder<Optional<T>> findFirst() {
+  public CompletionRunner<Optional<T>> findFirst() {
     return addTerminalStage(Stage.FindFirst.INSTANCE);
   }
 
@@ -336,18 +336,18 @@ public final class PublisherBuilder<T> {
    * @param collector The collector to collect the elements.
    * @param <R>       The result of the collector.
    * @param <A>       The accumulator type.
-   * @return A {@link CompletionBuilder} that emits the collected result.
+   * @return A {@link CompletionRunner} that emits the collected result.
    */
-  public <R, A> CompletionBuilder<R> collect(Collector<? super T, A, R> collector) {
+  public <R, A> CompletionRunner<R> collect(Collector<? super T, A, R> collector) {
     return addTerminalStage(new Stage.Collect(collector));
   }
 
   /**
    * Collect the elements emitted by this publisher builder into a {@link List}
    *
-   * @return A {@link CompletionBuilder} that emits the list.
+   * @return A {@link CompletionRunner} that emits the list.
    */
-  public CompletionBuilder<List<T>> toList() {
+  public CompletionRunner<List<T>> toList() {
     return collect(Collectors.toList());
   }
 
@@ -355,9 +355,9 @@ public final class PublisherBuilder<T> {
    * Connect the outlet of the {@link Publisher} built by this builder to the given {@link Subscriber}.
    *
    * @param subscriber The subscriber to connect.
-   * @return A {@link CompletionBuilder} that completes when the stream completes.
+   * @return A {@link CompletionRunner} that completes when the stream completes.
    */
-  public CompletionBuilder<Void> to(Subscriber<T> subscriber) {
+  public CompletionRunner<Void> to(Subscriber<T> subscriber) {
     return addTerminalStage(new Stage.SubscriberStage(subscriber));
   }
 
@@ -365,9 +365,9 @@ public final class PublisherBuilder<T> {
    * Connect the outlet of this publisher builder to the given {@link SubscriberBuilder} graph.
    *
    * @param subscriber The subscriber builder to connect.
-   * @return A {@link CompletionBuilder} that completes when the stream completes.
+   * @return A {@link CompletionRunner} that completes when the stream completes.
    */
-  public <R> CompletionBuilder<R> to(SubscriberBuilder<T, R> subscriber) {
+  public <R> CompletionRunner<R> to(SubscriberBuilder<T, R> subscriber) {
     return addTerminalStage(new InternalStages.Nested(subscriber.getGraphBuilder()));
   }
 
@@ -418,7 +418,7 @@ public final class PublisherBuilder<T> {
     return new PublisherBuilder<>(graphBuilder.addStage(stage));
   }
 
-  private <R> CompletionBuilder<R> addTerminalStage(Stage stage) {
-    return new CompletionBuilder<>(graphBuilder.addStage(stage));
+  private <R> CompletionRunner<R> addTerminalStage(Stage stage) {
+    return new CompletionRunner<>(graphBuilder.addStage(stage));
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/package-info.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/package-info.java
@@ -33,7 +33,7 @@
  * {@link org.eclipse.microprofile.reactive.streams.CompletionSubscriber}</li>
  * <li>{@link org.eclipse.microprofile.reactive.streams.ProcessorBuilder}, which when built produces a
  * {@link org.reactivestreams.Processor}</li>
- * <li>{@link org.eclipse.microprofile.reactive.streams.CompletionBuilder}, which when built produces a
+ * <li>{@link org.eclipse.microprofile.reactive.streams.CompletionRunner}, which when built produces a
  * {@link java.util.concurrent.CompletionStage}</li>
  * </ul>
  * <p>
@@ -56,9 +56,10 @@
  * result is the {@link java.lang.Void} type, and the {@link java.util.concurrent.CompletionStage} is only useful for
  * signalling normal or error termination of the stream.
  * <p>
- * The {@link CompletionBuilder} builds a closed graph, in that case both a {@link org.reactivestreams.Publisher}
- * and {@link org.reactivestreams.Subscriber} have been provided, and building the graph will run it and return
- * the result of the {@link org.reactivestreams.Subscriber} as a {@link java.util.concurrent.CompletionStage}.
+ * The {@link org.eclipse.microprofile.reactive.streams.CompletionRunner} builds a closed graph, in that case both a
+ * {@link org.reactivestreams.Publisher} and {@link org.reactivestreams.Subscriber} have been provided, and building the
+ * graph will run it and return the result of the {@link org.reactivestreams.Subscriber} as a
+ * {@link java.util.concurrent.CompletionStage}.
  * <p>
  * An example use of this API is perhaps you have a {@link org.reactivestreams.Publisher} of rows from a database,
  * and you want to output it as a comma separated list of lines to publish to an HTTP client request body, which

--- a/streams/spec/src/main/asciidoc/architecture.asciidoc
+++ b/streams/spec/src/main/asciidoc/architecture.asciidoc
@@ -81,7 +81,9 @@ There are four different shapes of streams that can be built:
 
 image::shapes.png[Shapes,400,400,align="center"]
 
-* Closed graphs. A closed graph has no inlet or outlet, both having being provided in during the construction of the graph. It is represented as a `CompletionStage` of the result of the stream, when built. This is called a `CompletionBuilder`.
+* Closed graphs. A closed graph has no inlet or outlet, both having being provided in during the construction of the graph
+. It is represented as a `CompletionStage` of the result of the stream. This is called a `CompletionRunner`. The result is
+ retrieved using the `run` method.
 
 image::graph.png[Closed graph,250,250,align="center"]
 
@@ -94,7 +96,7 @@ When this happens, the stream becomes a closed graph, since there is no longer a
 PublisherBuilder<Integer> intsPublisher =
   ReactiveStreams.of(1, 2, 3); <1>
 
-CompletionBuilder<List<Integer>> intsResult =
+CompletionRunner<List<Integer>> intsResult =
   intsPublisher.toList(); <2>
 ----
 <1> A publisher of integers 1, 2 and 3.
@@ -117,7 +119,10 @@ SubscriberBuilder<Integer, List<String>> toListSubscriber =
 
 When MicroProfile specifications provide an API that uses Reactive Streams, it is intended that application developers can return and pass the builder interfaces directly to the MicroProfile APIs.
 In many cases, application developers will not need to run the streams themselves.
-However, should they need to run the streams directly themselves, they can do so by using the streams `build` or `run` methods. `PublisherBuilder`, `SubscriberBuilder` and `ProcessorBuilder` all provide a `build` method that returns a `Publisher`, `CompletionSubscriber` and `Processor` respectively, while `CompletionBuilder`, since building it will actually run the stream, provides a `run` method that returns a `CompletionStage`.
+However, should they need to run the streams directly themselves, they can do so by using the streams `build` or `run`
+methods. `PublisherBuilder`, `SubscriberBuilder` and `ProcessorBuilder` all provide a `build` method that returns a
+`Publisher`, `CompletionSubscriber` and `Processor` respectively, while `CompletionRunner`, since it actually
+runs the stream, provides a `run` method that returns a `CompletionStage`.
 
 The `CompletionSubscriber` class is so named because, where a `CompletionStage` is a stage of asynchronous computation that completes with a value or an error, a `CompletionSubscriber` is subscriber to an asynchronous stream that completes with a value or an error.
 

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FilterStageVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/FilterStageVerification.java
@@ -19,7 +19,7 @@
 
 package org.eclipse.microprofile.reactive.streams.tck;
 
-import org.eclipse.microprofile.reactive.streams.CompletionBuilder;
+import org.eclipse.microprofile.reactive.streams.CompletionRunner;
 import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
@@ -73,7 +73,7 @@ public class FilterStageVerification extends AbstractStageVerification {
 
   @Test
   public void filterStageShouldInstantiatePredicateOncePerRun() {
-    CompletionBuilder<List<Integer>> completion =
+    CompletionRunner<List<Integer>> completion =
         ReactiveStreams.of(1, 2, 3, 4, 5, 6)
             .skip(3)
             .toList();


### PR DESCRIPTION
This change has been discussed during the MP Reactive call (July 3rd) and is related to #16.

In addition to the code change, the spec has been updated.
