### PR TITLE
Fix build after the merge of the `collect` stage

### DIFF
--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
@@ -355,9 +355,9 @@ public final class PublisherBuilder<T> {
    * @param accumulator an associative, non-interfering, stateless function for incorporating an additional element into a
    *              result
    * @param <R>  The result of the collector.
-   * @return A {@link CompletionBuilder} that emits the collected result.
+   * @return A {@link CompletionRunner} that emits the collected result.
    */
-  public <R> CompletionBuilder<R> collect(Supplier<R> supplier, BiConsumer<R,? super T> accumulator) {
+  public <R> CompletionRunner<R> collect(Supplier<R> supplier, BiConsumer<R,? super T> accumulator) {
     // The combiner is not used, so the used, but should not be null
     return addTerminalStage(new Stage.Collect(Collector.of(supplier, accumulator, (a, b) -> a)));
   }


### PR DESCRIPTION
#56 was developed before the renaming from CompletionBuilder to CompletionRunner (#58). As a consequence, the compilation fails. This PR fixes it.