### PR TITLE
Added method for accessing the graph directly

### DIFF
--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionRunner.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/CompletionRunner.java
@@ -19,6 +19,7 @@
 
 package org.eclipse.microprofile.reactive.streams;
 
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
 import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
 
 import java.util.concurrent.CompletionStage;
@@ -58,6 +59,10 @@ public final class CompletionRunner<T> {
    * @return A completion stage that will be redeemed with the result of the stream, or an error if the stream fails.
    */
   public CompletionStage<T> run(ReactiveStreamsEngine engine) {
-    return engine.buildCompletion(graphBuilder.build(false, false));
+    return engine.buildCompletion(toGraph());
+  }
+
+  Graph toGraph() {
+    return graphBuilder.build(false, false);
   }
 }

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/GraphAccessor.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/GraphAccessor.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams;
+
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
+
+/**
+ * Exists to allow access to the {@code toGraph} methods on each builder, so that these methods don't have to be
+ * exposed publicly in the API.
+ *
+ * This is intended only for use by implementations of the API, to get direct access to the graphs without having to
+ * build a publisher, processor or subscriber. This is particularly useful for cases where an implementation would
+ * like to do additional manipulation using its own API to the stream, but have those manipulations fused to the
+ * graph being manipulated.
+ */
+public class GraphAccessor {
+
+  private GraphAccessor() {
+  }
+
+  /**
+   * Build the graph for the given {@link PublisherBuilder}.
+   *
+   * @param publisherBuilder The builder to build the graph for.
+   * @return The built graph.
+   */
+  public static Graph buildGraphFor(PublisherBuilder<?> publisherBuilder) {
+    return publisherBuilder.toGraph();
+  }
+
+  /**
+   * Build the graph for the given {@link ProcessorBuilder}.
+   *
+   * @param processorBuilder The builder to build the graph for.
+   * @return The built graph.
+   */
+  public static Graph buildGraphFor(ProcessorBuilder<?, ?> processorBuilder) {
+    return processorBuilder.toGraph();
+  }
+
+  /**
+   * Build the graph for the given {@link SubscriberBuilder}.
+   *
+   * @param subscriberBuilder The builder to build the graph for.
+   * @return The built graph.
+   */
+  public static Graph buildGraphFor(SubscriberBuilder<?, ?> subscriberBuilder) {
+    return subscriberBuilder.toGraph();
+  }
+
+  /**
+   * Build the graph for the given {@link CompletionRunner}.
+   *
+   * @param completionRunner The runner to build the graph for.
+   * @return The built graph.
+   */
+  public static Graph buildGraphFor(CompletionRunner<?> completionRunner) {
+    return completionRunner.toGraph();
+  }
+
+}

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
@@ -19,6 +19,7 @@
 
 package org.eclipse.microprofile.reactive.streams;
 
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
 import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
 import org.eclipse.microprofile.reactive.streams.spi.Stage;
 import org.reactivestreams.Processor;
@@ -432,7 +433,11 @@ public final class ProcessorBuilder<T, R> {
    * @return A {@link Processor} that will run this stream.
    */
   public Processor<T, R> buildRs(ReactiveStreamsEngine engine) {
-    return engine.buildProcessor(graphBuilder.build(true, true));
+    return engine.buildProcessor(toGraph());
+  }
+
+  Graph toGraph() {
+    return graphBuilder.build(true, true);
   }
 
   private <S> ProcessorBuilder<T, S> addStage(Stage stage) {

--- a/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
+++ b/streams/api/src/main/java/org/eclipse/microprofile/reactive/streams/SubscriberBuilder.java
@@ -19,6 +19,7 @@
 
 package org.eclipse.microprofile.reactive.streams;
 
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
 import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
 import org.eclipse.microprofile.reactive.streams.spi.Stage;
 
@@ -62,7 +63,11 @@ public final class SubscriberBuilder<T, R> {
    * @return A {@link CompletionSubscriber} that will run this stream.
    */
   public CompletionSubscriber<T, R> build(ReactiveStreamsEngine engine) {
-    return engine.buildSubscriber(graphBuilder.build(true, false));
+    return engine.buildSubscriber(toGraph());
+  }
+
+  Graph toGraph() {
+    return graphBuilder.build(true, false);
   }
 
   ReactiveStreamsGraphBuilder getGraphBuilder() {

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/GraphAccessorVerification.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/GraphAccessorVerification.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.eclipse.microprofile.reactive.streams.GraphAccessor;
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.spi.Graph;
+import org.eclipse.microprofile.reactive.streams.spi.Stage;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test for the GraphAccessor class.
+ *
+ * This does not need an implementation of the engine to verify it.
+ */
+public class GraphAccessorVerification {
+
+  @Test
+  public void buildGraphForPublisherShouldProduceTheCorrectGraph() {
+    Graph graph = GraphAccessor.buildGraphFor(ReactiveStreams.of(1).map(i -> i * 2));
+    assertEquals(2, graph.getStages().size());
+    List<Stage> stages = new ArrayList<>(graph.getStages());
+    assertInstanceOf(stages.get(0), Stage.Of.class);
+    assertInstanceOf(stages.get(1), Stage.Map.class);
+  }
+
+  @Test
+  public void buildGraphForProcessorShouldProduceTheCorrectGraph() {
+    Graph graph = GraphAccessor.buildGraphFor(ReactiveStreams.<Integer>builder().filter(i -> i > 10).takeWhile(i -> i < 20));
+    assertEquals(2, graph.getStages().size());
+    List<Stage> stages = new ArrayList<>(graph.getStages());
+    assertInstanceOf(stages.get(0), Stage.Filter.class);
+    assertInstanceOf(stages.get(1), Stage.TakeWhile.class);
+  }
+
+  @Test
+  public void buildGraphForSubscriberShouldProduceTheCorrectGraph() {
+    Graph graph = GraphAccessor.buildGraphFor(ReactiveStreams.<Integer>builder().limit(10).toList());
+    assertEquals(2, graph.getStages().size());
+    List<Stage> stages = new ArrayList<>(graph.getStages());
+    assertInstanceOf(stages.get(0), Stage.Limit.class);
+    assertInstanceOf(stages.get(1), Stage.Collect.class);
+  }
+
+  @Test
+  public void buildGraphForCompletionRunnerShouldProduceTheCorrectGraph() {
+    Graph graph = GraphAccessor.buildGraphFor(ReactiveStreams.failed(new Exception()).distinct().cancel());
+    assertEquals(3, graph.getStages().size());
+    List<Stage> stages = new ArrayList<>(graph.getStages());
+    assertInstanceOf(stages.get(0), Stage.Failed.class);
+    assertInstanceOf(stages.get(1), Stage.Distinct.class);
+    assertEquals(Stage.Cancel.INSTANCE, stages.get(2));
+  }
+
+  private static void assertInstanceOf(Object obj, Class<?> clazz) {
+    assertTrue(clazz.isInstance(obj), obj + " is not a an instance of " + clazz);
+  }
+}

--- a/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ReactiveStreamsTck.java
+++ b/streams/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/ReactiveStreamsTck.java
@@ -113,6 +113,9 @@ public abstract class ReactiveStreamsTck<E extends ReactiveStreamsEngine> {
       allTests.addAll(stageVerification.reactiveStreamsTckVerifiers());
     }
 
+    // Add tests that aren't dependent on the dependencies.
+    allTests.add(new GraphAccessorVerification());
+
     return allTests.stream().filter(this::isEnabled).toArray();
   }
 

--- a/streams/tck/src/test/java/org/eclipse/microprofile/reactive/streams/tck/TckTest.java
+++ b/streams/tck/src/test/java/org/eclipse/microprofile/reactive/streams/tck/TckTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.streams.tck;
+
+import org.testng.annotations.Factory;
+
+/**
+ * This runs any tests that don't require an implementation to run.
+ */
+public class TckTest {
+
+  @Factory
+  public Object[] independentTests() {
+    return new Object[] {
+        new GraphAccessorVerification()
+    };
+  }
+}


### PR DESCRIPTION
We use this in Lightbend's MicroProfile Messaging implementation, it gives a way to build, for example, a `Flow` from a `ProcessorBuilder`, without having to build a `Processor`.

Note that all the `toGraph` methods are package private, so never appear in the user API, so this remains strictly an implementation detail except for the `GraphAccessor` class. It would have been nice to put that in the `spi` package, but unfortunately then it wouldn't be able to access the package private `toGraph` methods.